### PR TITLE
Events not send to regions

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachine.java
@@ -15,7 +15,6 @@
  */
 package org.springframework.statemachine;
 
-import org.springframework.messaging.Message;
 import org.springframework.statemachine.listener.StateMachineListener;
 import org.springframework.statemachine.region.Region;
 import org.springframework.statemachine.state.State;
@@ -37,31 +36,6 @@ public interface StateMachine<S, E> extends Region<S, E> {
 	 * @return initial state
 	 */
 	State<S,E> getInitialState();
-
-	/**
-	 * Start the state machine.
-	 */
-	void start();
-
-	/**
-	 * Stop the state machine.
-	 */
-	void stop();
-
-	/**
-	 * Send an event {@code E} wrapped with a {@link Message} to the state
-	 * machine.
-	 *
-	 * @param event the wrapped event to send
-	 */
-	void sendEvent(Message<E> event);
-
-	/**
-	 * Send an event {@code E} to the state machine.
-	 *
-	 * @param event the event to send
-	 */
-	void sendEvent(E event);
 
 	/**
 	 * Adds the state listener.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/region/Region.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/region/Region.java
@@ -17,13 +17,14 @@ package org.springframework.statemachine.region;
 
 import java.util.Collection;
 
+import org.springframework.messaging.Message;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.transition.Transition;
 
 /**
  * A region is an orthogonal part of either a composite state or a state
  * machine. It contains states and transitions.
- * 
+ *
  * @author Janne Valkealahti
  *
  * @param <S> the type of state
@@ -32,27 +33,51 @@ import org.springframework.statemachine.transition.Transition;
 public interface Region<S, E> {
 
 	/**
+	 * Start the region.
+	 */
+	void start();
+
+	/**
+	 * Stop the region.
+	 */
+	void stop();
+
+	/**
+	 * Send an event {@code E} wrapped with a {@link Message} to the region.
+	 *
+	 * @param event the wrapped event to send
+	 */
+	void sendEvent(Message<E> event);
+
+	/**
+	 * Send an event {@code E} to the region.
+	 *
+	 * @param event the event to send
+	 */
+	void sendEvent(E event);
+
+	/**
 	 * Gets the current {@link State}.
 	 *
 	 * @return current state
 	 */
 	State<S,E> getState();
-	
+
 	/**
 	 * Gets the {@link State}s defined in this region. Returned collection is
 	 * an unmodifiable copy because states in a state machine are immutable.
 	 *
 	 * @return immutable copy of states
-	 */	
+	 */
 	Collection<State<S, E>> getStates();
-	
+
 	/**
 	 * Gets a {@link Transition}s for this region.
-	 * 
+	 *
 	 * @return immutable copy of transitions
 	 */
 	Collection<Transition<S,E>> getTransitions();
-	
+
 	/**
 	 * Checks if region complete. Region is considered to be completed if it has
 	 * reached its end state and no further event processing is happening.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/AbstractState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/AbstractState.java
@@ -18,6 +18,7 @@ package org.springframework.statemachine.state;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import org.springframework.messaging.Message;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.action.Action;
@@ -134,6 +135,10 @@ public abstract class AbstractState<S, E> implements State<S, E> {
 			this.regions.addAll(regions);
 		}
 		this.submachine = submachine;
+	}
+
+	@Override
+	public void sendEvent(Message<E> event) {
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/State.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/State.java
@@ -17,6 +17,7 @@ package org.springframework.statemachine.state;
 
 import java.util.Collection;
 
+import org.springframework.messaging.Message;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
@@ -29,6 +30,13 @@ import org.springframework.statemachine.action.Action;
  * @param <E> the type of event
  */
 public interface State<S, E> {
+
+	/**
+	 * Send an event {@code E} wrapped with a {@link Message} to the state.
+	 *
+	 * @param event the wrapped event to send
+	 */
+	void sendEvent(Message<E> event);
 
 	/**
 	 * Initiate an exit sequence for the state.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -166,6 +166,12 @@ public abstract class AbstractStateMachine<S, E> extends LifecycleObjectSupport 
 		if (log.isDebugEnabled()) {
 			log.debug("Queue event " + event);
 		}
+
+		// TODO: should not do here
+		if (currentState != null) {
+			currentState.sendEvent(event);
+		}
+
 		eventQueue.add(event);
 		scheduleEventQueueProcessing();
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
@@ -62,7 +62,8 @@ public abstract class AbstractStateMachineTests {
 
 	public enum TestStates {
 		SI,S1,S2,S3,S4,SF,
-		S11,S111,S21,S211
+		S11,S111,S112,S12,S121,S122,
+		S21,S211
 	}
 
 	public enum TestEvents {


### PR DESCRIPTION
- refactor event processing around state
  interfaces order to pass event from a state
  machine into a regions.