### PR TITLE
Support history pseudostates

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurer.java
@@ -53,6 +53,10 @@ public class DefaultStateConfigurer<S, E>
 
 	private S end;
 
+	private S history;
+
+	private History historyType;
+
 	private final Collection<S> choices = new ArrayList<S>();
 
 	@Override
@@ -72,6 +76,13 @@ public class DefaultStateConfigurer<S, E>
 			}
 			if (choices.contains(s.getState())) {
 				s.setPseudoStateKind(PseudoStateKind.CHOICE);
+			}
+			if (s.getState() == history) {
+				if (History.SHALLOW == historyType) {
+					s.setPseudoStateKind(PseudoStateKind.HISTORY_SHALLOW);
+				} else if (History.DEEP == historyType) {
+					s.setPseudoStateKind(PseudoStateKind.HISTORY_DEEP);
+				}
 			}
 		}
 		builder.addStateData(stateDatas);
@@ -149,6 +160,14 @@ public class DefaultStateConfigurer<S, E>
 	@Override
 	public StateConfigurer<S, E> choice(S choice) {
 		choices.add(choice);
+		return this;
+	}
+
+	@Override
+	public StateConfigurer<S, E> history(S history, History type) {
+		this.history = history;
+		this.historyType = type;
+		state(history);
 		return this;
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
@@ -123,4 +123,31 @@ public interface StateConfigurer<S, E> extends
 	 */
 	StateConfigurer<S, E> choice(S choice);
 
+	/**
+	 * Specify a state {@code S} to be history pseudo state.
+	 *
+	 * @param history the history pseudo state
+	 * @param type the history pseudo state type
+	 * @return configurer for chaining
+	 */
+	StateConfigurer<S, E> history(S history, History type);
+
+	/**
+	 * Enumeration of a possible history pseudostate type.
+	 */
+	public enum History {
+
+		/**
+		 * Shallow history is a pseudo state representing the most
+		 * recent substate of a submachine.
+		 */
+		SHALLOW,
+
+		/**
+		 * Deep history is a shallow history recursively reactivating
+		 * the substates of the most recent substate.
+		 */
+		DEEP
+	}
+
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/HistoryPseudoState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/HistoryPseudoState.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.state;
+
+import org.springframework.statemachine.StateContext;
+import org.springframework.util.Assert;
+
+/**
+ * History implementation of a {@link PseudoState}.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <S> the type of state
+ * @param <E> the type of event
+ */
+public class HistoryPseudoState<S, E> extends AbstractPseudoState<S, E> {
+
+	private State<S, E> state;
+
+	/**
+	 * Instantiates a new history pseudo state.
+	 *
+	 * @param kind the kind
+	 */
+	public HistoryPseudoState(PseudoStateKind kind) {
+		super(kind);
+		Assert.isTrue(PseudoStateKind.HISTORY_SHALLOW == kind || PseudoStateKind.HISTORY_DEEP == kind,
+				"Pseudo state must be either shallow or deep");
+	}
+
+	/**
+	 * Sets the current recorded state.
+	 *
+	 * @param state the state
+	 */
+	public void setState(State<S, E> state) {
+		this.state = state;
+	}
+
+	/**
+	 * Gets the current recorded state.
+	 *
+	 * @return the current recorded state.
+	 */
+	public State<S, E> getState() {
+		return state;
+	}
+
+	@Override
+	public State<S, E> entry(E event, StateContext<S, E> context) {
+		return state;
+	}
+
+}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/PseudoStateKind.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/PseudoStateKind.java
@@ -16,7 +16,7 @@
 package org.springframework.statemachine.state;
 
 /**
- * Defines enumeration of a {@link PseudoState} kind. This is uses within a
+ * Defines enumeration of a {@link PseudoState} kind. This is used within a
  * transitive states indicating its kind.
  *
  * @author Janne Valkealahti
@@ -31,6 +31,12 @@ public enum PseudoStateKind {
 	END,
 
 	/** Choice kind */
-	CHOICE
+	CHOICE,
+
+	/** History deep kind */
+	HISTORY_DEEP,
+
+	/** History shallow kind */
+	HISTORY_SHALLOW
 
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/StateMachineState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/StateMachineState.java
@@ -137,6 +137,8 @@ public class StateMachineState<S, E> extends AbstractState<S, E> {
 		// enable default transition and state
 		if (getSubmachine().getState() != null && context.getTransition().getSource().getId() != getSubmachine().getState().getId()) {
 			getSubmachine().stop();
+		} else if (!isSubstate(context.getTransition().getTarget(), context.getTransition().getSource())) {
+			getSubmachine().stop();
 		}
 		Collection<? extends Action<S, E>> actions = getExitActions();
 		if (actions != null && !isLocal(context)) {
@@ -176,6 +178,12 @@ public class StateMachineState<S, E> extends AbstractState<S, E> {
 		} else {
 			return false;
 		}
+	}
+
+	private boolean isSubstate(State<S, E> left, State<S, E> right) {
+		Collection<State<S, E>> c = left.getStates();
+		c.remove(left);
+		return c.contains(right);
 	}
 
 	@Override

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
@@ -63,9 +63,9 @@ public abstract class AbstractStateMachineTests {
 	}
 
 	public enum TestStates {
-		SI,S1,S2,S3,S4,SF,
+		SI,S1,S2,S3,S4,SF,SH,
 		S10,S11,S101,S111,S112,S12,S121,S122,S13,
-		S20,S21,S201,S211,
+		S20,S21,S201,S211,S212,
 		S1011,S1012,S2011,S2012,
 		S30,S31,S32,S33
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/HistoryStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/HistoryStateTests.java
@@ -15,38 +15,23 @@
  */
 package org.springframework.statemachine.state;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.EnumStateMachine;
-import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.StateMachineSystemConstants;
-import org.springframework.statemachine.TestUtils;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
-import org.springframework.statemachine.transition.DefaultExternalTransition;
-import org.springframework.statemachine.transition.Transition;
-import org.springframework.statemachine.trigger.EventTrigger;
+import org.springframework.statemachine.config.configurers.StateConfigurer.History;
 
-/**
- * Tests for states using a submachine.
- *
- * @author Janne Valkealahti
- *
- */
-public class SubmachineStateTests extends AbstractStateMachineTests {
+public class HistoryStateTests extends AbstractStateMachineTests {
 
 	@Override
 	protected AnnotationConfigApplicationContext buildContext() {
@@ -54,52 +39,8 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 	}
 
 	@Test
-	public void testSimpleSubmachineState() {
-
-		State<TestStates,TestEvents> stateSI = new EnumState<TestStates,TestEvents>(TestStates.SI);
-		State<TestStates,TestEvents> stateS1 = new EnumState<TestStates,TestEvents>(TestStates.S1);
-		State<TestStates,TestEvents> stateS2 = new EnumState<TestStates,TestEvents>(TestStates.S2);
-		State<TestStates,TestEvents> stateS3 = new EnumState<TestStates,TestEvents>(TestStates.S3);
-
-		Collection<State<TestStates,TestEvents>> states = new ArrayList<State<TestStates,TestEvents>>();
-		states.add(stateSI);
-		states.add(stateS1);
-		states.add(stateS2);
-		states.add(stateS3);
-
-		Collection<Transition<TestStates,TestEvents>> transitions = new ArrayList<Transition<TestStates,TestEvents>>();
-
-		DefaultExternalTransition<TestStates,TestEvents> transitionFromSIToS1 =
-				new DefaultExternalTransition<TestStates,TestEvents>(stateSI, stateS1, null, TestEvents.E1, null, new EventTrigger<TestStates,TestEvents>(TestEvents.E1));
-
-		DefaultExternalTransition<TestStates,TestEvents> transitionFromS1ToS2 =
-				new DefaultExternalTransition<TestStates,TestEvents>(stateS1, stateS2, null, TestEvents.E2, null, new EventTrigger<TestStates,TestEvents>(TestEvents.E2));
-
-		DefaultExternalTransition<TestStates,TestEvents> transitionFromS2ToS3 =
-				new DefaultExternalTransition<TestStates,TestEvents>(stateS2, stateS3, null, TestEvents.E3, null, new EventTrigger<TestStates,TestEvents>(TestEvents.E3));
-
-		transitions.add(transitionFromSIToS1);
-		transitions.add(transitionFromS1ToS2);
-		transitions.add(transitionFromS2ToS3);
-
-		SyncTaskExecutor taskExecutor = new SyncTaskExecutor();
-		EnumStateMachine<TestStates, TestEvents> machine = new EnumStateMachine<TestStates, TestEvents>(states, transitions, stateSI);
-		machine.setTaskExecutor(taskExecutor);
-		machine.start();
-
-		StateMachineState<TestStates,TestEvents> state = new StateMachineState<TestStates,TestEvents>(TestStates.S4, machine);
-
-		assertThat(state.isSimple(), is(false));
-		assertThat(state.isComposite(), is(false));
-		assertThat(state.isOrthogonal(), is(false));
-		assertThat(state.isSubmachineState(), is(true));
-
-		assertThat(state.getIds(), contains(TestStates.S4, TestStates.SI));
-	}
-
-	@Test
 	@SuppressWarnings("unchecked")
-	public void testFromSimpleToOtherSubstate() {
+	public void testShallowInSubmachine() {
 		context.register(BaseConfig.class, Config1.class);
 		context.refresh();
 		EnumStateMachine<TestStates,TestEvents> machine =
@@ -116,7 +57,7 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void testAllSubmachinesRunningInitialsTakesToDeep() throws Exception {
+	public void testDeep() {
 		context.register(BaseConfig.class, Config2.class);
 		context.refresh();
 		EnumStateMachine<TestStates,TestEvents> machine =
@@ -124,51 +65,16 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 		assertThat(machine, notNullValue());
 		machine.start();
 		machine.sendEvent(TestEvents.E1);
-
-		assertThat(machine.isRunning(), is(true));
-
-		State<TestStates, TestEvents> s = machine.getState();
-		StateMachine<TestStates, TestEvents> m = ((StateMachineState<TestStates, TestEvents>) s).getSubmachine();
-		boolean r = TestUtils.readField("running", m);
-		assertThat(r, is(true));
-
-		s = m.getState();
-		m = ((StateMachineState<TestStates, TestEvents>) s).getSubmachine();
-		r = TestUtils.readField("running", m);
-		assertThat(r, is(true));
-
-		assertThat(machine.getState().getIds(), contains(TestStates.S2, TestStates.S20, TestStates.S2011));
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testAllSubmachinesRunningInitialsNotTakeToDeep() throws Exception {
-		context.register(BaseConfig.class, Config3.class);
-		context.refresh();
-		EnumStateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, EnumStateMachine.class);
-		assertThat(machine, notNullValue());
-		machine.start();
-		machine.sendEvent(TestEvents.E1);
-
-		assertThat(machine.isRunning(), is(true));
-
-		State<TestStates, TestEvents> s = machine.getState();
-		StateMachine<TestStates, TestEvents> m = ((StateMachineState<TestStates, TestEvents>) s).getSubmachine();
-		boolean r = TestUtils.readField("running", m);
-		assertThat(r, is(true));
-
-		s = m.getState();
-		m = ((StateMachineState<TestStates, TestEvents>) s).getSubmachine();
-		r = TestUtils.readField("running", m);
-		assertThat(r, is(true));
+		machine.sendEvent(TestEvents.E2);
+		machine.sendEvent(TestEvents.E3);
+		machine.sendEvent(TestEvents.E4);
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S2, TestStates.S21, TestStates.S212));
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
-	public void testAllSubmachinesStopped() throws Exception {
+	public void testShallow() {
 		context.register(BaseConfig.class, Config3.class);
 		context.refresh();
 		EnumStateMachine<TestStates,TestEvents> machine =
@@ -177,23 +83,10 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 		machine.start();
 		machine.sendEvent(TestEvents.E1);
 		machine.sendEvent(TestEvents.E2);
-
-		assertThat(machine.isRunning(), is(true));
-
-		State<TestStates, TestEvents> s1 = machine.getState();
-		StateMachine<TestStates, TestEvents> m1 = ((StateMachineState<TestStates, TestEvents>) s1).getSubmachine();
-
-		State<TestStates, TestEvents> s2 = m1.getState();
-		StateMachine<TestStates, TestEvents> m2 = ((StateMachineState<TestStates, TestEvents>) s2).getSubmachine();
-
 		machine.sendEvent(TestEvents.E3);
+		machine.sendEvent(TestEvents.E4);
 
-		boolean r1 = TestUtils.readField("running", m1);
-		assertThat(r1, is(false));
-		boolean r2 = TestUtils.readField("running", m2);
-		assertThat(r2, is(false));
-
-		assertThat(machine.getState().getIds(), contains(TestStates.S1));
+		assertThat(machine.getState().getIds(), contains(TestStates.S2, TestStates.S21, TestStates.S211));
 	}
 
 	@Configuration
@@ -212,7 +105,9 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 						.parent(TestStates.S2)
 						.initial(TestStates.S20)
 						.state(TestStates.S20)
-						.state(TestStates.S21);
+						.state(TestStates.S21)
+						.history(TestStates.SH, History.SHALLOW);
+
 		}
 
 		@Override
@@ -235,7 +130,7 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 					.and()
 				.withExternal()
 					.source(TestStates.S1)
-					.target(TestStates.S21)
+					.target(TestStates.SH)
 					.event(TestEvents.E4);
 		}
 
@@ -258,13 +153,13 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 						.initial(TestStates.S20)
 						.state(TestStates.S20)
 						.state(TestStates.S21)
+						.history(TestStates.SH, History.DEEP)
 						.and()
 						.withStates()
-							.parent(TestStates.S20)
-							.initial(TestStates.S2011)
-							.state(TestStates.S2011)
-							.state(TestStates.S2012);
-
+							.parent(TestStates.S21)
+							.initial(TestStates.S211)
+							.state(TestStates.S211)
+							.state(TestStates.S212);
 		}
 
 		@Override
@@ -272,8 +167,23 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 			transitions
 				.withExternal()
 					.source(TestStates.S1)
-					.target(TestStates.S2)
-					.event(TestEvents.E1);
+					.target(TestStates.S211)
+					.event(TestEvents.E1)
+					.and()
+				.withExternal()
+					.source(TestStates.S211)
+					.target(TestStates.S212)
+					.event(TestEvents.E2)
+					.and()
+				.withExternal()
+					.source(TestStates.S212)
+					.target(TestStates.S1)
+					.event(TestEvents.E3)
+					.and()
+				.withExternal()
+					.source(TestStates.S1)
+					.target(TestStates.SH)
+					.event(TestEvents.E4);
 		}
 
 	}
@@ -295,6 +205,7 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 						.initial(TestStates.S20)
 						.state(TestStates.S20)
 						.state(TestStates.S21)
+						.history(TestStates.SH, History.SHALLOW)
 						.and()
 						.withStates()
 							.parent(TestStates.S21)
@@ -308,7 +219,7 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 			transitions
 				.withExternal()
 					.source(TestStates.S1)
-					.target(TestStates.S212)
+					.target(TestStates.S211)
 					.event(TestEvents.E1)
 					.and()
 				.withExternal()
@@ -319,7 +230,12 @@ public class SubmachineStateTests extends AbstractStateMachineTests {
 				.withExternal()
 					.source(TestStates.S212)
 					.target(TestStates.S1)
-					.event(TestEvents.E3);
+					.event(TestEvents.E3)
+					.and()
+				.withExternal()
+					.source(TestStates.S1)
+					.target(TestStates.SH)
+					.event(TestEvents.E4);
 		}
 
 	}


### PR DESCRIPTION
- Fixes #50 bug which were revealed by
  trying to use history state concepts.
- Fixes #38 for history features.
- Base functionality for deep and shallow
  histories.
- Some housekeeping and polish before doing
  more system wide spring cleaning.