### PR TITLE
RegionState not created with nested states

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/EnumStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/EnumStateMachineFactory.java
@@ -162,10 +162,8 @@ public class EnumStateMachineFactory<S extends Enum<S>, E extends Enum<E>> exten
 					m.setBeanFactory(getBeanFactory());
 				}
 				m.afterPropertiesSet();
-
 				machine = m;
-
-
+				machineMap.put(peek.getParent(), machine);
 			} else {
 				machine = buildMachine(machineMap, stateMap, stateDatas, transitionsData, getBeanFactory(),
 						contextEvents, defaultExtendedState, stateMachineTransitions);


### PR DESCRIPTION
- EnumStateMachineFactory didn't add created machine
  which wrapped region states into a internal
  machine map which is used to resolve built machines.
- Adding test which simply tests nested regions.
- Fixes #54