### PR TITLE
Triggerless transition doesn't work from initial to terminate

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -371,7 +371,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 			}
 		}
 	}
-	
+
 	private State<S, E> findStateWithPseudoState(PseudoState<S, E> pseudoState) {
 		for (State<S, E> s : states) {
 			if (s.getPseudoState() == pseudoState) {

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/LifecycleObjectSupport.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/LifecycleObjectSupport.java
@@ -101,8 +101,8 @@ public abstract class LifecycleObjectSupport implements InitializingBean, SmartL
 		this.lifecycleLock.lock();
 		try {
 			if (!this.running) {
-				this.doStart();
 				this.running = true;
+				this.doStart();
 				if (log.isInfoEnabled()) {
 					log.info("started " + this);
 				} else {


### PR DESCRIPTION
- Fix correct handling in this case.
- Tune lifecycle so that recursive calls to
  start() in a same thread doesn't cause multiple
  calls to doStart().