### PR TITLE
StateMachineBuilder TimerTrigger NullPointerException

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
@@ -544,6 +544,10 @@ public abstract class AbstractStateMachineFactory<S, E> extends LifecycleObjectS
 				if (beanFactory != null) {
 					t.setBeanFactory(beanFactory);
 				}
+                                if( taskScheduler != null )
+                                {
+                                        t.setTaskScheduler(taskScheduler);
+                                }
 				trigger = t;
 			}
 


### PR DESCRIPTION
When using the StateMachineBuilder outside of the springboot framework, it is not possible to create a timer trigger, because the taskScheduler is not set on the TimerTrigger/LifecycleObjectSupport when the AbstractStateMachineFactory is building the TimerTrigger. This results in a NullPointerException while building the StateMachine.

This problem has also been reported on stackoverflow

http://stackoverflow.com/questions/34633583/crash-on-statemachinebuilder-timer