### PR TITLE
Allow user to use machine id

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachineContext.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachineContext.java
@@ -29,6 +29,13 @@ import java.util.Map;
 public interface StateMachineContext<S, E> {
 
 	/**
+	 * Gets the machine id.
+	 *
+	 * @return the machine id
+	 */
+	String getId();
+
+	/**
 	 * Gets the child contexts if any.
 	 *
 	 * @return the child contexts

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/ObjectStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/ObjectStateMachineFactory.java
@@ -59,9 +59,10 @@ public class ObjectStateMachineFactory<S, E> extends AbstractStateMachineFactory
 			Collection<Transition<S, E>> transitions, State<S, E> initialState, Transition<S, E> initialTransition,
 			Message<E> initialEvent, ExtendedState extendedState, PseudoState<S, E> historyState,
 			Boolean contextEventsEnabled, BeanFactory beanFactory, TaskExecutor taskExecutor,
-			TaskScheduler taskScheduler, String beanName) {
+			TaskScheduler taskScheduler, String beanName, String machineId) {
 		ObjectStateMachine<S, E> machine = new ObjectStateMachine<S, E>(states, transitions, initialState, initialTransition, initialEvent,
 				extendedState);
+		machine.setId(machineId);
 		machine.setHistoryState(historyState);
 		if (contextEventsEnabled != null) {
 			machine.setContextEventsEnabled(contextEventsEnabled);
@@ -73,7 +74,7 @@ public class ObjectStateMachineFactory<S, E> extends AbstractStateMachineFactory
 			machine.setTaskExecutor(taskExecutor);
 		}
 		if (taskScheduler != null) {
-			machine.setTaskScheduler(taskScheduler);;
+			machine.setTaskScheduler(taskScheduler);
 		}
 		if (machine instanceof BeanNameAware) {
 			((BeanNameAware)machine).setBeanName(beanName);

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/StateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/StateMachineFactory.java
@@ -19,7 +19,7 @@ import org.springframework.statemachine.StateMachine;
 
 /**
  * {@code StateMachineFactory} is a strategy interface building {@link StateMachine}s.
- * 
+ *
  * @author Janne Valkealahti
  *
  * @param <S> the type of state
@@ -29,9 +29,17 @@ public interface StateMachineFactory<S, E> {
 
 	/**
 	 * Build a new {@link StateMachine} instance.
-	 * 
+	 *
 	 * @return a new state machine instance.
 	 */
 	StateMachine<S, E> getStateMachine();
 
+	/**
+	 * Build a new {@link StateMachine} instance
+	 * with a given machine id.
+	 *
+	 * @param machineId the machine id
+	 * @return a new state machine instance.
+	 */
+	StateMachine<S, E> getStateMachine(String machineId);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
@@ -52,6 +52,7 @@ public class StateMachineConfigurationBuilder<S, E>
 		extends AbstractConfiguredAnnotationBuilder<ConfigurationData<S, E>, StateMachineConfigurationConfigurer<S, E>, StateMachineConfigurationBuilder<S, E>>
 		implements StateMachineConfigurationConfigurer<S, E> {
 
+	private String machineId;
 	private BeanFactory beanFactory;
 	private TaskExecutor taskExecutor;
 	private TaskScheduler taskScheculer;
@@ -117,7 +118,16 @@ public class StateMachineConfigurationBuilder<S, E>
 	protected ConfigurationData<S, E> performBuild() throws Exception {
 		return new ConfigurationData<S, E>(beanFactory, taskExecutor, taskScheculer, autoStart, ensemble, listeners,
 				securityEnabled, transitionSecurityAccessDecisionManager, eventSecurityAccessDecisionManager, eventSecurityRule,
-				transitionSecurityRule, verifierEnabled, verifier);
+				transitionSecurityRule, verifierEnabled, verifier, machineId);
+	}
+
+	/**
+	 * Sets the machine id.
+	 *
+	 * @param machineId the new machine id
+	 */
+	public void setMachineId(String machineId) {
+		this.machineId = machineId;
 	}
 
 	/**

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ConfigurationConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ConfigurationConfigurer.java
@@ -33,6 +33,8 @@ import org.springframework.statemachine.listener.StateMachineListener;
 public interface ConfigurationConfigurer<S, E> extends
 		AnnotationConfigurerBuilder<StateMachineConfigurationConfigurer<S, E>> {
 
+	ConfigurationConfigurer<S, E> machineId(String id);
+
 	/**
 	 * Specify a {@link BeanFactory}.
 	 *

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultConfigurationConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultConfigurationConfigurer.java
@@ -39,6 +39,7 @@ public class DefaultConfigurationConfigurer<S, E>
 		extends AnnotationConfigurerAdapter<ConfigurationData<S, E>, StateMachineConfigurationConfigurer<S, E>, StateMachineConfigurationBuilder<S, E>>
 		implements ConfigurationConfigurer<S, E> {
 
+	private String machineId;
 	private BeanFactory beanFactory;
 	private TaskExecutor taskExecutor;
 	private TaskScheduler taskScheculer;
@@ -47,11 +48,18 @@ public class DefaultConfigurationConfigurer<S, E>
 
 	@Override
 	public void configure(StateMachineConfigurationBuilder<S, E> builder) throws Exception {
+		builder.setMachineId(machineId);
 		builder.setBeanFactory(beanFactory);
 		builder.setTaskExecutor(taskExecutor);
 		builder.setTaskScheculer(taskScheculer);
 		builder.setAutoStart(autoStart);
 		builder.setStateMachineListeners(listeners);
+	}
+
+	@Override
+	public ConfigurationConfigurer<S, E> machineId(String id) {
+		this.machineId = id;
+		return this;
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ConfigurationData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ConfigurationData.java
@@ -41,6 +41,7 @@ import org.springframework.statemachine.security.SecurityRule;
  */
 public class ConfigurationData<S, E> {
 
+	private final String machineId;
 	private final BeanFactory beanFactory;
 	private final TaskExecutor taskExecutor;
 	private final TaskScheduler taskScheduler;
@@ -60,7 +61,7 @@ public class ConfigurationData<S, E> {
 	 */
 	public ConfigurationData() {
 		this(null, new SyncTaskExecutor(), new ConcurrentTaskScheduler(), false, null, new ArrayList<StateMachineListener<S, E>>(), false,
-				null, null, null, null, true, new DefaultStateMachineModelVerifier<S, E>());
+				null, null, null, null, true, new DefaultStateMachineModelVerifier<S, E>(), null);
 	}
 
 	/**
@@ -79,13 +80,14 @@ public class ConfigurationData<S, E> {
 	 * @param transitionSecurityRule the transition security rule
 	 * @param verifierEnabled the verifier enabled flag
 	 * @param verifier the state machine model verifier
+	 * @param machineId the machine id
 	 */
 	public ConfigurationData(BeanFactory beanFactory, TaskExecutor taskExecutor,
 			TaskScheduler taskScheduler, boolean autoStart, StateMachineEnsemble<S, E> ensemble,
 			List<StateMachineListener<S, E>> listeners, boolean securityEnabled,
 			AccessDecisionManager transitionSecurityAccessDecisionManager, AccessDecisionManager eventSecurityAccessDecisionManager,
 			SecurityRule eventSecurityRule, SecurityRule transitionSecurityRule, boolean verifierEnabled,
-			StateMachineModelVerifier<S, E> verifier) {
+			StateMachineModelVerifier<S, E> verifier, String machineId) {
 		this.beanFactory = beanFactory;
 		this.taskExecutor = taskExecutor;
 		this.taskScheduler = taskScheduler;
@@ -99,6 +101,11 @@ public class ConfigurationData<S, E> {
 		this.transitionSecurityRule = transitionSecurityRule;
 		this.verifierEnabled = verifierEnabled;
 		this.verifier = verifier;
+		this.machineId = machineId;
+	}
+
+	public String getMachineId() {
+		return machineId;
 	}
 
 	/**

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/AbstractStateMachinePersister.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/AbstractStateMachinePersister.java
@@ -129,6 +129,6 @@ public abstract class AbstractStateMachinePersister<S, E, T> implements StateMac
 				}
 			}
 		}
-		return new DefaultStateMachineContext<S, E>(childs, id, null, null, extendedState, historyStates);
+		return new DefaultStateMachineContext<S, E>(childs, id, null, null, extendedState, historyStates, stateMachine.getId());
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/region/Region.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/region/Region.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.statemachine.region;
 
 import java.util.Collection;
+import java.util.UUID;
 
 import org.springframework.messaging.Message;
 import org.springframework.statemachine.listener.StateMachineListener;
@@ -37,6 +38,13 @@ public interface Region<S, E> {
 	 * Gets the region and state machine unique id.
 	 *
 	 * @return the region and state machine unique id
+	 */
+	UUID getUuid();
+
+	/**
+	 * Gets the region and state machine id.
+	 *
+	 * @return the region and state machine id
 	 */
 	String getId();
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -100,7 +100,9 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 
 	private Boolean initialEnabled = null;
 
-	private String id = UUID.randomUUID().toString();
+	private UUID uuid = UUID.randomUUID();
+
+	private String id;
 
 	private volatile Message<E> forwardedInitialEvent;
 
@@ -490,6 +492,8 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		if (currentState != null) {
 			buf.append(StringUtils.collectionToCommaDelimitedString(currentState.getIds()));
 		}
+		buf.append(" / uuid=");
+		buf.append(uuid);
 		buf.append(" / id=");
 		buf.append(id);
 		return buf.toString();
@@ -507,6 +511,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		if (log.isDebugEnabled()) {
 			log.debug("Request to reset state machine: stateMachine=[" + this + "] stateMachineContext=[" + stateMachineContext + "]");
 		}
+		setId(stateMachineContext.getId());
 		S state = stateMachineContext.getState();
 		boolean stateSet = false;
 		// handle state reset
@@ -623,8 +628,22 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 	}
 
 	@Override
+	public UUID getUuid() {
+		return uuid;
+	}
+
+	@Override
 	public String getId() {
 		return id;
+	}
+
+	/**
+	 * Sets the machine id.
+	 *
+	 * @param id the new machine id
+	 */
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	protected synchronized boolean acceptEvent(Message<E> message) {

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineContext.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineContext.java
@@ -33,6 +33,7 @@ import org.springframework.statemachine.StateMachineContext;
  */
 public class DefaultStateMachineContext<S, E> implements StateMachineContext<S, E> {
 
+	private final String id;
 	private final List<StateMachineContext<S, E>> childs;
 	private final S state;
 	private final Map<S, S> historyStates;
@@ -69,6 +70,21 @@ public class DefaultStateMachineContext<S, E> implements StateMachineContext<S, 
 	/**
 	 * Instantiates a new default state machine context.
 	 *
+	 * @param state the state
+	 * @param event the event
+	 * @param eventHeaders the event headers
+	 * @param extendedState the extended state
+	 * @param historyStates the history state mappings
+	 * @param id the machine id
+	 */
+	public DefaultStateMachineContext(S state, E event, Map<String, Object> eventHeaders, ExtendedState extendedState,
+			Map<S, S> historyStates, String id) {
+		this(new ArrayList<StateMachineContext<S, E>>(), state, event, eventHeaders, extendedState, historyStates, id);
+	}
+
+	/**
+	 * Instantiates a new default state machine context.
+	 *
 	 * @param childs the child state machine contexts
 	 * @param state the state
 	 * @param event the event
@@ -92,12 +108,34 @@ public class DefaultStateMachineContext<S, E> implements StateMachineContext<S, 
 	 */
 	public DefaultStateMachineContext(List<StateMachineContext<S, E>> childs, S state, E event,
 			Map<String, Object> eventHeaders, ExtendedState extendedState, Map<S, S> historyStates) {
+		this(childs, state, event, eventHeaders, extendedState, historyStates, null);
+	}
+
+	/**
+	 * Instantiates a new default state machine context.
+	 *
+	 * @param childs the child state machine contexts
+	 * @param state the state
+	 * @param event the event
+	 * @param eventHeaders the event headers
+	 * @param extendedState the extended state
+	 * @param historyStates the history state mappings
+	 * @param id the machine id
+	 */
+	public DefaultStateMachineContext(List<StateMachineContext<S, E>> childs, S state, E event,
+			Map<String, Object> eventHeaders, ExtendedState extendedState, Map<S, S> historyStates, String id) {
 		this.childs = childs;
 		this.state = state;
 		this.event = event;
 		this.eventHeaders = eventHeaders;
 		this.extendedState = extendedState;
 		this.historyStates = historyStates != null ? historyStates : new HashMap<S, S>();
+		this.id = id;
+	}
+
+	@Override
+	public String getId() {
+		return id;
 	}
 
 	@Override
@@ -132,7 +170,7 @@ public class DefaultStateMachineContext<S, E> implements StateMachineContext<S, 
 
 	@Override
 	public String toString() {
-		return "DefaultStateMachineContext [childs=" + childs + ", state=" + state + ", historyStates=" + historyStates + ", event=" + event
-				+ ", eventHeaders=" + eventHeaders + ", extendedState=" + extendedState + "]";
+		return "DefaultStateMachineContext [id=" + id + ", childs=" + childs + ", state=" + state + ", historyStates=" + historyStates
+				+ ", event=" + event + ", eventHeaders=" + eventHeaders + ", extendedState=" + extendedState + "]";
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -405,7 +405,7 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 		if (!map.containsKey(StateMachineSystemConstants.STATEMACHINE_IDENTIFIER)) {
 			// don't set sm id if it's already present because
 			// we want to keep the originating sm id
-			map.put(StateMachineSystemConstants.STATEMACHINE_IDENTIFIER, stateMachine.getId());
+			map.put(StateMachineSystemConstants.STATEMACHINE_IDENTIFIER, stateMachine.getUuid());
 		}
 		return new DefaultStateContext<S, E>(Stage.TRANSITION, message, new MessageHeaders(map), stateMachine.getExtendedState(), transition, stateMachine, null, null, null);
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/access/StateMachineAccessTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/access/StateMachineAccessTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.springframework.messaging.Message;
@@ -171,6 +172,11 @@ public class StateMachineAccessTests {
 
 		@Override
 		public void setInitialEnabled(boolean enabled) {
+		}
+
+		@Override
+		public UUID getUuid() {
+			return null;
 		}
 
 		@Override

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
@@ -59,7 +59,7 @@ public class StateMachineModelTests {
 
 		ConfigurationData<String, String> configurationData = new ConfigurationData<>(beanFactory, taskExecutor, taskScheduler, autoStart,
 				ensemble, listeners, securityEnabled, transitionSecurityAccessDecisionManager, eventSecurityAccessDecisionManager,
-				eventSecurityRule, transitionSecurityRule, verifierEnabled, verifier);
+				eventSecurityRule, transitionSecurityRule, verifierEnabled, verifier, null);
 
 		Collection<StateData<String, String>> stateData = new ArrayList<>();
 		StateData<String, String> stateData1 = new StateData<String, String>(null, null, "S1", null, null, null);

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests3.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests3.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.persist;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.HashMap;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.AbstractStateMachineTests;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineContext;
+import org.springframework.statemachine.StateMachinePersist;
+import org.springframework.statemachine.config.EnableStateMachineFactory;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.config.builders.StateMachineConfigurationConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+
+public class StateMachinePersistTests3 extends AbstractStateMachineTests {
+
+	@Override
+	protected AnnotationConfigApplicationContext buildContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+
+	@Test
+	public void testPersistMachineId() throws Exception {
+		context.register(Config1.class);
+		context.refresh();
+		InMemoryStateMachinePersist1 stateMachinePersist = new InMemoryStateMachinePersist1();
+		StateMachinePersister<String, String, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
+		@SuppressWarnings("unchecked")
+		StateMachineFactory<String, String> stateMachineFactory = context.getBean(StateMachineFactory.class);
+
+		StateMachine<String,String> stateMachine = stateMachineFactory.getStateMachine("testid2");
+		assertThat(stateMachine, notNullValue());
+		assertThat(stateMachine.getId(), is("testid2"));
+
+		persister.persist(stateMachine, "xxx");
+
+		stateMachine = stateMachineFactory.getStateMachine();
+		assertThat(stateMachine, notNullValue());
+		assertThat(stateMachine.getId(), nullValue());
+
+		stateMachine = persister.restore(stateMachine, "xxx");
+		assertThat(stateMachine.getId(), is("testid2"));
+	}
+
+	@Configuration
+	@EnableStateMachineFactory
+	public static class Config1 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineConfigurationConfigurer<String, String> config) throws Exception {
+			config
+				.withConfiguration()
+					.autoStartup(true);
+		}
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2");
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E1");
+		}
+	}
+
+	static class InMemoryStateMachinePersist1 implements StateMachinePersist<String, String, String> {
+
+		private final HashMap<String, StateMachineContext<String, String>> contexts = new HashMap<>();
+
+		@Override
+		public void write(StateMachineContext<String, String> context, String contextOjb) throws Exception {
+			contexts.put(contextOjb, context);
+		}
+
+		@Override
+		public StateMachineContext<String, String> read(String contextOjb) throws Exception {
+			return contexts.get(contextOjb);
+		}
+	}
+}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.springframework.expression.ExpressionParser;
@@ -206,6 +207,11 @@ public class StateContextExpressionMethodsTests {
 
 		@Override
 		public ExtendedState getExtendedState() {
+			return null;
+		}
+
+		@Override
+		public UUID getUuid() {
 			return null;
 		}
 

--- a/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachineEnsembleTests.java
+++ b/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachineEnsembleTests.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -753,6 +754,11 @@ public class ZookeeperStateMachineEnsembleTests extends AbstractZookeeperTests {
 
 		@Override
 		public ExtendedState getExtendedState() {
+			return null;
+		}
+
+		@Override
+		public UUID getUuid() {
 			return null;
 		}
 


### PR DESCRIPTION
- change original id to uuid.
- This new id is now for user disposal.
- Currently only meant for a top-level machine.
- Can be set via annotation config, model classes or via
  new StateMachineFactory.getStateMachine(String).
- Is persisted with DefaultStateMachinePersister and
  StateMachineContext.
- Related new tests in ConfigurationTests and StateMachinePersistTests3.
- Relates to #186