### PR TITLE
[Review only] First take on individual submachine config support

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurer.java
@@ -23,7 +23,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.statemachine.config.builders.StateMachineStateBuilder;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerAdapter;
@@ -57,6 +59,8 @@ public class DefaultStateConfigurer<S, E>
 	private final Collection<S> joins = new ArrayList<S>();
 	private final Collection<S> exits = new ArrayList<S>();
 	private final Collection<S> entrys = new ArrayList<S>();
+	private final Map<S, StateMachine<S, E>> submachines = new HashMap<>();
+	private final Map<S, StateMachineFactory<S, E>> submachinefactories = new HashMap<>();
 
 	@Override
 	public void configure(StateMachineStateBuilder<S, E> builder) throws Exception {
@@ -93,6 +97,8 @@ public class DefaultStateConfigurer<S, E>
 					s.setPseudoStateKind(PseudoStateKind.HISTORY_DEEP);
 				}
 			}
+			s.setSubmachine(submachines.get(s.getState()));
+			s.setSubmachineFactory(submachinefactories.get(s.getState()));
 		}
 		builder.addStateData(stateDatas);
 	}
@@ -126,6 +132,20 @@ public class DefaultStateConfigurer<S, E>
 	@Override
 	public StateConfigurer<S, E> state(S state) {
 		return state(state, (E[])null);
+	}
+
+	@Override
+	public StateConfigurer<S, E> state(S state, StateMachine<S, E> stateMachine) {
+		state(state);
+		submachines.put(state, stateMachine);
+		return this;
+	}
+
+	@Override
+	public StateConfigurer<S, E> state(S state, StateMachineFactory<S, E> stateMachineFactory) {
+		state(state);
+		submachinefactories.put(state, stateMachineFactory);
+		return this;
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
@@ -18,7 +18,9 @@ package org.springframework.statemachine.config.configurers;
 import java.util.Collection;
 import java.util.Set;
 
+import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerBuilder;
 import org.springframework.statemachine.state.State;
@@ -68,6 +70,26 @@ public interface StateConfigurer<S, E> extends
 	 * @return configurer for chaining
 	 */
 	StateConfigurer<S, E> state(S state);
+
+	/**
+	 * Specify a state {@code S} and its relation with a given
+	 * machine as substate machine.
+	 *
+	 * @param state the state
+	 * @param stateMachine the submachine
+	 * @return configurer for chaining
+	 */
+	StateConfigurer<S, E> state(S state, StateMachine<S, E> stateMachine);
+
+	/**
+	 * Specify a state {@code S} and its relation with a given
+	 * machine as substate machine factory.
+	 *
+	 * @param state the state
+	 * @param stateMachineFactory the submachine factory
+	 * @return configurer for chaining
+	 */
+	StateConfigurer<S, E> state(S state, StateMachineFactory<S, E> stateMachineFactory);
 
 	/**
 	 * Specify a state {@code S} with entry and exit {@link Action}s.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/StateData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/StateData.java
@@ -17,6 +17,7 @@ package org.springframework.statemachine.config.model;
 
 import java.util.Collection;
 
+import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.statemachine.state.PseudoStateKind;
@@ -37,6 +38,9 @@ public class StateData<S, E> {
 	private Object parent;
 	private Object region;
 	private S state;
+	private Collection<StateData<S, E>> submachineStateData;
+	private StateMachine<S, E> submachine;
+	private StateMachineFactory<S, E> submachineFactory;
 	private Collection<E> deferred;
 	private Collection<? extends Action<S, E>> entryActions;
 	private Collection<? extends Action<S, E>> exitActions;
@@ -120,6 +124,69 @@ public class StateData<S, E> {
 	 */
 	public S getState() {
 		return state;
+	}
+
+	/**
+	 * Gets the submachine state data.
+	 *
+	 * @return the submachine state data
+	 */
+	public Collection<StateData<S, E>> getSubmachineStateData() {
+		return submachineStateData;
+	}
+
+	/**
+	 * Sets the submachine state data.
+	 *
+	 * @param submachineStateData the submachine state data
+	 */
+	public void setSubmachineStateData(Collection<StateData<S, E>> submachineStateData) {
+		this.submachineStateData = submachineStateData;
+	}
+
+	/**
+	 * Gets the submachine.
+	 *
+	 * @return the submachine
+	 */
+	public StateMachine<S, E> getSubmachine() {
+		return submachine;
+	}
+
+	/**
+	 * Sets the submachine.
+	 *
+	 * @param submachine the submachine
+	 */
+	public void setSubmachine(StateMachine<S, E> submachine) {
+		this.submachine = submachine;
+	}
+
+	/**
+	 * Gets the submachine factory.
+	 *
+	 * @return the submachine factory
+	 */
+	public StateMachineFactory<S, E> getSubmachineFactory() {
+		return submachineFactory;
+	}
+
+	/**
+	 * Sets the submachine factory.
+	 *
+	 * @param submachineFactory the submachine factory
+	 */
+	public void setSubmachineFactory(StateMachineFactory<S, E> submachineFactory) {
+		this.submachineFactory = submachineFactory;
+	}
+
+	/**
+	 * Sets the submachine factory.
+	 *
+	 * @param submachineFactory the submachine factory
+	 */
+	public void setSubmachine(StateMachineFactory<S, E> submachineFactory) {
+		this.submachineFactory = submachineFactory;
 	}
 
 	/**

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefEnumTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefEnumTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.state;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.AbstractStateMachineTests;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineSystemConstants;
+import org.springframework.statemachine.config.EnableStateMachine;
+import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+
+/**
+ * Tests for submachine references.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SubmachineRefEnumTests extends AbstractStateMachineTests {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSubmachineRef() throws Exception {
+		context.register(Config2.class, Config1.class);
+		context.refresh();
+		StateMachine<TestStates, TestEvents> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		assertThat(machine, notNullValue());
+		machine.start();
+		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S1));
+		machine.sendEvent(TestEvents.E1);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20));
+		machine.sendEvent(TestEvents.E2);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
+		machine.sendEvent(TestEvents.E3);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S31));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSubmachineRefDifferentTypes() throws Exception {
+		context.register(Config4.class, Config3.class);
+		context.refresh();
+		StateMachine<Object, Object> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		assertThat(machine, notNullValue());
+		machine.start();
+		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S1));
+		machine.sendEvent(Events1.E1);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S2, States2.S20));
+		machine.sendEvent(Events2.E2);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S2, States2.S21, States2.S30));
+		machine.sendEvent(Events2.E3);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S2, States2.S21, States2.S31));
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config1 extends EnumStateMachineConfigurerAdapter<TestStates, TestEvents> {
+
+		@Autowired
+		@Qualifier("subStateMachine")
+		private StateMachine<TestStates, TestEvents> subStateMachine;
+
+		@Override
+		public void configure(StateMachineStateConfigurer<TestStates, TestEvents> states) throws Exception {
+			states
+				.withStates()
+					.initial(TestStates.S1)
+					.state(TestStates.S2, subStateMachine);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<TestStates, TestEvents> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(TestStates.S1).target(TestStates.S2).event(TestEvents.E1);
+		}
+
+	}
+
+	@Configuration
+	@EnableStateMachine(name = "subStateMachine")
+	static class Config2 extends EnumStateMachineConfigurerAdapter<TestStates, TestEvents> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<TestStates, TestEvents> states) throws Exception {
+			states
+				.withStates()
+					.initial(TestStates.S20)
+					.state(TestStates.S21)
+					.and()
+					.withStates()
+						.parent(TestStates.S21)
+						.initial(TestStates.S30)
+						.state(TestStates.S31);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<TestStates, TestEvents> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(TestStates.S20).target(TestStates.S21).event(TestEvents.E2).and()
+				.withExternal()
+					.source(TestStates.S30).target(TestStates.S31).event(TestEvents.E3);
+		}
+
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config3 extends StateMachineConfigurerAdapter<Object, Object> {
+
+		@Autowired
+		@Qualifier("subStateMachine")
+		private StateMachine<Object, Object> subStateMachine;
+
+		@Override
+		public void configure(StateMachineStateConfigurer<Object, Object> states) throws Exception {
+			states
+				.withStates()
+					.initial(States1.S1)
+					.state(States1.S2, subStateMachine);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<Object, Object> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(States1.S1).target(States1.S2).event(Events1.E1);
+		}
+
+	}
+
+	@Configuration
+	@EnableStateMachine(name = "subStateMachine")
+	static class Config4 extends StateMachineConfigurerAdapter<Object, Object> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<Object, Object> states) throws Exception {
+			states
+				.withStates()
+					.initial(States2.S20)
+					.state(States2.S21)
+					.and()
+					.withStates()
+						.parent(States2.S21)
+						.initial(States2.S30)
+						.state(States2.S31);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<Object, Object> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(States2.S20).target(States2.S21).event(Events2.E2).and()
+				.withExternal()
+					.source(States2.S30).target(States2.S31).event(Events2.E3);
+		}
+
+	}
+
+	@Override
+	protected AnnotationConfigApplicationContext buildContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+
+	enum States1 {
+		S1, S2;
+	}
+
+	enum Events1 {
+		E1
+	}
+
+	enum States2 {
+		S20, S21, S30, S31;
+	}
+
+	enum Events2 {
+		E2, E3;
+	}
+}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.state;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.AbstractStateMachineTests;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineSystemConstants;
+import org.springframework.statemachine.config.EnableStateMachine;
+import org.springframework.statemachine.config.EnableStateMachineFactory;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+
+/**
+ * Tests for submachine references.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class SubmachineRefTests extends AbstractStateMachineTests {
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSubmachineRef() throws Exception {
+		context.register(Config2.class, Config1.class);
+		context.refresh();
+		StateMachine<String, String> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		assertThat(machine, notNullValue());
+		machine.start();
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S1"));
+		machine.sendEvent("E1");
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S20"));
+		machine.sendEvent("E2");
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S30"));
+		machine.sendEvent("E3");
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S31"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSubmachineRefWithFactory() throws Exception {
+		context.register(Config4.class, Config3.class);
+		context.refresh();
+		StateMachineFactory<String, String> factory = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+		StateMachine<String, String> machine = factory.getStateMachine();
+		assertThat(machine, notNullValue());
+		machine.start();
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S1"));
+		machine.sendEvent("E1");
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S20"));
+		machine.sendEvent("E2");
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S30"));
+		machine.sendEvent("E3");
+		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S31"));
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config1 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Autowired
+		@Qualifier("subStateMachine")
+		private StateMachine<String, String> subStateMachine;
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2", subStateMachine);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1").target("S2").event("E1");
+		}
+
+	}
+
+	@Configuration
+	@EnableStateMachine(name = "subStateMachine")
+	static class Config2 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S20")
+					.state("S21")
+					.and()
+					.withStates()
+						.parent("S21")
+						.initial("S30")
+						.state("S31");
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S20").target("S21").event("E2").and()
+				.withExternal()
+					.source("S30").target("S31").event("E3");
+		}
+
+	}
+
+	@Configuration
+	@EnableStateMachineFactory
+	static class Config3 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Autowired
+		@Qualifier("subStateMachineFactory")
+		private StateMachineFactory<String, String> subStateMachineFactory;
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2", subStateMachineFactory);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1").target("S2").event("E1");
+		}
+
+	}
+
+	@Configuration
+	@EnableStateMachineFactory(name = "subStateMachineFactory")
+	static class Config4 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S20")
+					.state("S21")
+					.and()
+					.withStates()
+						.parent("S21")
+						.initial("S30")
+						.state("S31");
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S20").target("S21").event("E2").and()
+				.withExternal()
+					.source("S30").target("S31").event("E3");
+		}
+
+	}
+
+	@Override
+	protected AnnotationConfigApplicationContext buildContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+}

--- a/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
+++ b/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
@@ -609,6 +609,22 @@ public class UmlStateMachineModelFactoryTests extends AbstractUmlTests {
 		context.refresh();
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSimpleSubmachineRef() throws Exception {
+		context.register(Config20.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent("E1");
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2", "S20"));
+		stateMachine.sendEvent("E2");
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2", "S21", "S30"));
+		stateMachine.sendEvent("E3");
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2", "S21", "S31"));
+	}
+
 	@Configuration
 	@EnableStateMachine
 	public static class Config2 extends StateMachineConfigurerAdapter<String, String> {
@@ -981,6 +997,23 @@ public class UmlStateMachineModelFactoryTests extends AbstractUmlTests {
 		@Bean
 		public StateMachineModelFactory<String, String> modelFactory() {
 			return new UmlStateMachineModelFactory("classpath:org/springframework/statemachine/uml/broken-model-shadowentries.uml");
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	public static class Config20 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineModelConfigurer<String, String> model) throws Exception {
+			model
+				.withModel()
+					.factory(modelFactory());
+		}
+
+		@Bean
+		public StateMachineModelFactory<String, String> modelFactory() {
+			return new UmlStateMachineModelFactory("classpath:org/springframework/statemachine/uml/simple-submachineref.uml");
 		}
 	}
 

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-submachineref.di
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-submachineref.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-submachineref.notation
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-submachineref.notation
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <notation:Diagram xmi:id="_UeniYCWmEeaXAJvnS1wEeA" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_UeoJcCWmEeaXAJvnS1wEeA" type="StateMachine_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_UeoJcSWmEeaXAJvnS1wEeA" type="StateMachine_NameLabel">
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UeoJciWmEeaXAJvnS1wEeA" width="700" height="20"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_GI5kAFYMEea0mabmDF9_2w" type="StateMachine_RegionCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_UeoJdCWmEeaXAJvnS1wEeA" type="Region_Shape">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_UeoJdSWmEeaXAJvnS1wEeA" source="RegionAnnotationKey">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_UeoJdiWmEeaXAJvnS1wEeA" key="RegionZoneKey" value=""/>
+          </eAnnotations>
+          <children xmi:type="notation:BasicCompartment" xmi:id="_GI6yIFYMEea0mabmDF9_2w" type="Region_SubvertexCompartment">
+            <children xmi:type="notation:Shape" xmi:id="_ZgBmwCWmEeaXAJvnS1wEeA" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_ZgBmwiWmEeaXAJvnS1wEeA" type="State_NameLabel"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_ZgBmwyWmEeaXAJvnS1wEeA" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_ZgCN0CWmEeaXAJvnS1wEeA" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_GI8AQFYMEea0mabmDF9_2w" type="State_RegionCompartment">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgCN0iWmEeaXAJvnS1wEeA"/>
+              </children>
+              <element xmi:type="uml:State" href="simple-submachineref.uml#_Zf3OsCWmEeaXAJvnS1wEeA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ZgBmwSWmEeaXAJvnS1wEeA" x="131" y="55"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_bxBZACWmEeaXAJvnS1wEeA" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_bxBZAiWmEeaXAJvnS1wEeA" type="State_NameLabel"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_bxBZAyWmEeaXAJvnS1wEeA" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_bxBZBCWmEeaXAJvnS1wEeA" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_GI8AQVYMEea0mabmDF9_2w" type="State_RegionCompartment">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bxBZBiWmEeaXAJvnS1wEeA"/>
+              </children>
+              <element xmi:type="uml:State" href="simple-submachineref.uml#_bw8ggCWmEeaXAJvnS1wEeA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_bxBZASWmEeaXAJvnS1wEeA" x="281" y="55"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_NzAUECWoEeaXAJvnS1wEeA" type="Pseudostate_InitialShape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_NzAUEiWoEeaXAJvnS1wEeA" type="Pseudostate_InitialFloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_NzAUEyWoEeaXAJvnS1wEeA" x="25" y="3"/>
+              </children>
+              <children xmi:type="notation:DecorationNode" xmi:id="_NzAUFCWoEeaXAJvnS1wEeA" type="Pseudostate_InitialStereotypeLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_NzAUFSWoEeaXAJvnS1wEeA" x="25" y="-10"/>
+              </children>
+              <element xmi:type="uml:Pseudostate" href="simple-submachineref.uml#_Ny60gCWoEeaXAJvnS1wEeA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_NzAUESWoEeaXAJvnS1wEeA" x="42" y="55"/>
+            </children>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UeoJeCWmEeaXAJvnS1wEeA"/>
+          </children>
+          <element xmi:type="uml:Region" href="simple-submachineref.uml#_UekfECWmEeaXAJvnS1wEeA"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UeoJeSWmEeaXAJvnS1wEeA" width="700" height="287"/>
+        </children>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UeoJeiWmEeaXAJvnS1wEeA" y="20" width="700" height="290"/>
+      </children>
+      <element xmi:type="uml:StateMachine" href="simple-submachineref.uml#_UduxkCWmEeaXAJvnS1wEeA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_UeoJeyWmEeaXAJvnS1wEeA" x="30" y="30" width="700" height="310"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_UeoJfCWmEeaXAJvnS1wEeA" name="diagram_compatibility_version" stringValue="1.2.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_UeoJfSWmEeaXAJvnS1wEeA"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_UeoJfiWmEeaXAJvnS1wEeA">
+      <owner xmi:type="uml:Model" href="simple-submachineref.uml#_Uc2AwCWmEeaXAJvnS1wEeA"/>
+    </styles>
+    <element xmi:type="uml:StateMachine" href="simple-submachineref.uml#_UduxkCWmEeaXAJvnS1wEeA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_PSOEECWoEeaXAJvnS1wEeA" type="Transition_Edge" source="_NzAUECWoEeaXAJvnS1wEeA" target="_ZgBmwCWmEeaXAJvnS1wEeA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_PSOrICWoEeaXAJvnS1wEeA" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSOrISWoEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PSOrIiWoEeaXAJvnS1wEeA" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSOrIyWoEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_PSOrJCWoEeaXAJvnS1wEeA" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_PSOrJSWoEeaXAJvnS1wEeA" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_PSOEESWoEeaXAJvnS1wEeA"/>
+      <element xmi:type="uml:Transition" href="simple-submachineref.uml#_PSFhMCWoEeaXAJvnS1wEeA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_PSOEEiWoEeaXAJvnS1wEeA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PSfw4CWoEeaXAJvnS1wEeA" id="(0.9,0.45)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_PSfw4SWoEeaXAJvnS1wEeA" id="(0.0,0.20454545454545456)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_QZP9kCWoEeaXAJvnS1wEeA" type="Transition_Edge" source="_ZgBmwCWmEeaXAJvnS1wEeA" target="_bxBZACWmEeaXAJvnS1wEeA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QZP9kyWoEeaXAJvnS1wEeA" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QZP9lCWoEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QZP9lSWoEeaXAJvnS1wEeA" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QZP9liWoEeaXAJvnS1wEeA" x="-3" y="-14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QZQkoCWoEeaXAJvnS1wEeA" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QZQkoSWoEeaXAJvnS1wEeA" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_QZP9kSWoEeaXAJvnS1wEeA"/>
+      <element xmi:type="uml:Transition" href="simple-submachineref.uml#_QZJ28CWoEeaXAJvnS1wEeA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QZP9kiWoEeaXAJvnS1wEeA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZi4gCWoEeaXAJvnS1wEeA" id="(1.0,0.4772727272727273)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QZi4gSWoEeaXAJvnS1wEeA" id="(0.0,0.4772727272727273)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_uOFKMCWmEeaXAJvnS1wEeA" type="PapyrusUMLStateMachineDiagram" name="SubStateMachine Diagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_uOFKMSWmEeaXAJvnS1wEeA" type="StateMachine_Shape" fillColor="14012867" gradient="16777215, 16777215, 0" lineColor="0">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_5NHDkCWmEeaXAJvnS1wEeA" source="PapyrusCSSForceValue">
+        <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_5NHDkSWmEeaXAJvnS1wEeA" key="gradient" value="true"/>
+      </eAnnotations>
+      <children xmi:type="notation:DecorationNode" xmi:id="_uOFKMiWmEeaXAJvnS1wEeA" type="StateMachine_NameLabel">
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uOFKMyWmEeaXAJvnS1wEeA" width="700" height="20"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_HA6KEFYMEea0mabmDF9_2w" type="StateMachine_RegionCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_uOFKNSWmEeaXAJvnS1wEeA" type="Region_Shape" fillColor="14012867" gradient="16777215, 16777215, 0" lineColor="0">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_uOFKNiWmEeaXAJvnS1wEeA" source="RegionAnnotationKey">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_uOFKNyWmEeaXAJvnS1wEeA" key="RegionZoneKey" value=""/>
+          </eAnnotations>
+          <children xmi:type="notation:BasicCompartment" xmi:id="_HA7YMFYMEea0mabmDF9_2w" type="Region_SubvertexCompartment">
+            <children xmi:type="notation:Shape" xmi:id="_Akb2cCWnEeaXAJvnS1wEeA" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_AkcdgCWnEeaXAJvnS1wEeA" type="State_NameLabel"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_AkcdgSWnEeaXAJvnS1wEeA" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_AkcdgiWnEeaXAJvnS1wEeA" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_HA7_QFYMEea0mabmDF9_2w" type="State_RegionCompartment">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AkcdhCWnEeaXAJvnS1wEeA"/>
+              </children>
+              <element xmi:type="uml:State" href="simple-submachineref.uml#_AkYMECWnEeaXAJvnS1wEeA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Akb2cSWnEeaXAJvnS1wEeA" x="135" y="64"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_B3mugCWnEeaXAJvnS1wEeA" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_B3mugiWnEeaXAJvnS1wEeA" type="State_NameLabel">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_EO5WACWnEeaXAJvnS1wEeA" width="291" height="20"/>
+              </children>
+              <children xmi:type="notation:DecorationNode" xmi:id="_B3nVkCWnEeaXAJvnS1wEeA" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_B3nVkSWnEeaXAJvnS1wEeA" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_HA8mUFYMEea0mabmDF9_2w" type="State_RegionCompartment">
+                <children xmi:type="notation:Shape" xmi:id="_FTfmkCWnEeaXAJvnS1wEeA" type="Region_Shape">
+                  <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_FTfmlCWnEeaXAJvnS1wEeA" source="RegionAnnotationKey">
+                    <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_FTfmlSWnEeaXAJvnS1wEeA" key="RegionZoneKey" value=""/>
+                  </eAnnotations>
+                  <children xmi:type="notation:BasicCompartment" xmi:id="_HA9NYFYMEea0mabmDF9_2w" type="Region_SubvertexCompartment">
+                    <children xmi:type="notation:Shape" xmi:id="_FTg0sSWnEeaXAJvnS1wEeA" type="State_Shape">
+                      <children xmi:type="notation:DecorationNode" xmi:id="_FThbwCWnEeaXAJvnS1wEeA" type="State_NameLabel"/>
+                      <children xmi:type="notation:DecorationNode" xmi:id="_FThbwSWnEeaXAJvnS1wEeA" type="State_FloatingNameLabel">
+                        <layoutConstraint xmi:type="notation:Location" xmi:id="_FThbwiWnEeaXAJvnS1wEeA" x="40"/>
+                      </children>
+                      <children xmi:type="notation:BasicCompartment" xmi:id="_HA9NYVYMEea0mabmDF9_2w" type="State_RegionCompartment">
+                        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FThbxCWnEeaXAJvnS1wEeA"/>
+                      </children>
+                      <element xmi:type="uml:State" href="simple-submachineref.uml#_FTg0sCWnEeaXAJvnS1wEeA"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTg0siWnEeaXAJvnS1wEeA" x="92" y="22"/>
+                    </children>
+                    <children xmi:type="notation:Shape" xmi:id="_IYY68CWnEeaXAJvnS1wEeA" type="State_Shape">
+                      <children xmi:type="notation:DecorationNode" xmi:id="_IYZiACWnEeaXAJvnS1wEeA" type="State_NameLabel"/>
+                      <children xmi:type="notation:DecorationNode" xmi:id="_IYZiASWnEeaXAJvnS1wEeA" type="State_FloatingNameLabel">
+                        <layoutConstraint xmi:type="notation:Location" xmi:id="_IYZiAiWnEeaXAJvnS1wEeA" x="40"/>
+                      </children>
+                      <children xmi:type="notation:BasicCompartment" xmi:id="_HA90cFYMEea0mabmDF9_2w" type="State_RegionCompartment">
+                        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IYZiBCWnEeaXAJvnS1wEeA"/>
+                      </children>
+                      <element xmi:type="uml:State" href="simple-submachineref.uml#_IYRmMCWnEeaXAJvnS1wEeA"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IYY68SWnEeaXAJvnS1wEeA" x="210" y="22"/>
+                    </children>
+                    <children xmi:type="notation:Shape" xmi:id="_LafaACWnEeaXAJvnS1wEeA" type="Pseudostate_InitialShape">
+                      <children xmi:type="notation:DecorationNode" xmi:id="_LagBECWnEeaXAJvnS1wEeA" type="Pseudostate_InitialFloatingNameLabel">
+                        <layoutConstraint xmi:type="notation:Location" xmi:id="_LagBESWnEeaXAJvnS1wEeA" x="25" y="3"/>
+                      </children>
+                      <children xmi:type="notation:DecorationNode" xmi:id="_LagBEiWnEeaXAJvnS1wEeA" type="Pseudostate_InitialStereotypeLabel">
+                        <layoutConstraint xmi:type="notation:Location" xmi:id="_LagBEyWnEeaXAJvnS1wEeA" x="25" y="-10"/>
+                      </children>
+                      <element xmi:type="uml:Pseudostate" href="simple-submachineref.uml#_LaVpACWnEeaXAJvnS1wEeA"/>
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_LafaASWnEeaXAJvnS1wEeA" x="16" y="29"/>
+                    </children>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTfmkyWnEeaXAJvnS1wEeA"/>
+                  </children>
+                  <element xmi:type="uml:Region" href="simple-submachineref.uml#_FTeYcCWnEeaXAJvnS1wEeA"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTfmkSWnEeaXAJvnS1wEeA" width="291" height="119"/>
+                </children>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B3nVkyWnEeaXAJvnS1wEeA" y="20" width="291" height="119"/>
+              </children>
+              <element xmi:type="uml:State" href="simple-submachineref.uml#_B3idECWnEeaXAJvnS1wEeA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B3mugSWnEeaXAJvnS1wEeA" x="259" y="64" width="291" height="139"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_N0bs4CWnEeaXAJvnS1wEeA" type="Pseudostate_InitialShape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_N0cT8CWnEeaXAJvnS1wEeA" type="Pseudostate_InitialFloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_N0cT8SWnEeaXAJvnS1wEeA" x="25" y="3"/>
+              </children>
+              <children xmi:type="notation:DecorationNode" xmi:id="_N0cT8iWnEeaXAJvnS1wEeA" type="Pseudostate_InitialStereotypeLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_N0cT8yWnEeaXAJvnS1wEeA" x="25" y="-10"/>
+              </children>
+              <element xmi:type="uml:Pseudostate" href="simple-submachineref.uml#_N0RU0CWnEeaXAJvnS1wEeA"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_N0bs4SWnEeaXAJvnS1wEeA" x="60" y="72"/>
+            </children>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uOFKOSWmEeaXAJvnS1wEeA"/>
+          </children>
+          <element xmi:type="uml:Region" href="simple-submachineref.uml#_uOEjICWmEeaXAJvnS1wEeA"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uOFKOiWmEeaXAJvnS1wEeA" width="700" height="287"/>
+        </children>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uOFKOyWmEeaXAJvnS1wEeA" y="20" width="700" height="290"/>
+      </children>
+      <element xmi:type="uml:StateMachine" href="simple-submachineref.uml#_ssBhkCWmEeaXAJvnS1wEeA"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_uOFKPCWmEeaXAJvnS1wEeA" x="30" y="30" width="700" height="310"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_uOFKPSWmEeaXAJvnS1wEeA" name="diagram_compatibility_version" stringValue="1.2.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_uOFKPiWmEeaXAJvnS1wEeA"/>
+    <styles xmi:type="style:PapyrusViewStyle" xmi:id="_uOFKPyWmEeaXAJvnS1wEeA">
+      <owner xmi:type="uml:Model" href="simple-submachineref.uml#_Uc2AwCWmEeaXAJvnS1wEeA"/>
+    </styles>
+    <element xmi:type="uml:StateMachine" href="simple-submachineref.uml#_ssBhkCWmEeaXAJvnS1wEeA"/>
+    <edges xmi:type="notation:Connector" xmi:id="_QOD2sCWnEeaXAJvnS1wEeA" type="Transition_Edge" source="_N0bs4CWnEeaXAJvnS1wEeA" target="_Akb2cCWnEeaXAJvnS1wEeA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_QOEdwCWnEeaXAJvnS1wEeA" type="Transition_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UaL0EFbXEea0mabmDF9_2w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QOEdwSWnEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QOEdwiWnEeaXAJvnS1wEeA" type="Transition_GuardLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_UaadkFbXEea0mabmDF9_2w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QOEdwyWnEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_QOEdxCWnEeaXAJvnS1wEeA" type="Transition_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Uaq8QFbXEea0mabmDF9_2w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_QOEdxSWnEeaXAJvnS1wEeA" x="-1" y="59"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_QOD2sSWnEeaXAJvnS1wEeA"/>
+      <element xmi:type="uml:Transition" href="simple-submachineref.uml#_QMMOcCWnEeaXAJvnS1wEeA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_QOD2siWnEeaXAJvnS1wEeA" points="[8, -1, -79, 0]$[79, -4, -8, -3]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPHmoCWnEeaXAJvnS1wEeA" id="(1.0,0.5)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_QPHmoSWnEeaXAJvnS1wEeA" id="(0.0,0.425531914893617)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Q84EgCWnEeaXAJvnS1wEeA" type="Transition_Edge" source="_LafaACWnEeaXAJvnS1wEeA" target="_FTg0sSWnEeaXAJvnS1wEeA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q84rkCWnEeaXAJvnS1wEeA" type="Transition_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_Vj0VoFbXEea0mabmDF9_2w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Q84rkSWnEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q84rkiWnEeaXAJvnS1wEeA" type="Transition_GuardLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VkBxAFbXEea0mabmDF9_2w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Q84rkyWnEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Q84rlCWnEeaXAJvnS1wEeA" type="Transition_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_VkQagFbXEea0mabmDF9_2w" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Q84rlSWnEeaXAJvnS1wEeA" y="59"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Q84EgSWnEeaXAJvnS1wEeA"/>
+      <element xmi:type="uml:Transition" href="simple-submachineref.uml#_Q8seUCWnEeaXAJvnS1wEeA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Q84EgiWnEeaXAJvnS1wEeA" points="[8, -1, -62, 0]$[66, -2, -4, -1]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q9g9sCWnEeaXAJvnS1wEeA" id="(1.0,0.45)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Q9g9sSWnEeaXAJvnS1wEeA" id="(0.0,0.36363636363636365)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_pbAnUCWnEeaXAJvnS1wEeA" type="Transition_Edge" source="_FTg0sSWnEeaXAJvnS1wEeA" target="_IYY68CWnEeaXAJvnS1wEeA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_pbBOYCWnEeaXAJvnS1wEeA" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pbBOYSWnEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pbBOYiWnEeaXAJvnS1wEeA" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pbBOYyWnEeaXAJvnS1wEeA" x="-2" y="-16"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_pbBOZCWnEeaXAJvnS1wEeA" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_pbBOZSWnEeaXAJvnS1wEeA" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_pbAnUSWnEeaXAJvnS1wEeA"/>
+      <element xmi:type="uml:Transition" href="simple-submachineref.uml#_pazL8CWnEeaXAJvnS1wEeA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_pbAnUiWnEeaXAJvnS1wEeA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pbuZACWnEeaXAJvnS1wEeA" id="(1.0,0.425531914893617)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_pbvAECWnEeaXAJvnS1wEeA" id="(0.0,0.425531914893617)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_IueqQCWoEeaXAJvnS1wEeA" type="Transition_Edge" source="_Akb2cCWnEeaXAJvnS1wEeA" target="_B3mugCWnEeaXAJvnS1wEeA">
+      <children xmi:type="notation:DecorationNode" xmi:id="_IueqQyWoEeaXAJvnS1wEeA" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IueqRCWoEeaXAJvnS1wEeA"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IueqRSWoEeaXAJvnS1wEeA" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IueqRiWoEeaXAJvnS1wEeA" x="-4" y="-14"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_IueqRyWoEeaXAJvnS1wEeA" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_IueqSCWoEeaXAJvnS1wEeA" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_IueqQSWoEeaXAJvnS1wEeA"/>
+      <element xmi:type="uml:Transition" href="simple-submachineref.uml#_IuR18CWoEeaXAJvnS1wEeA"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_IueqQiWoEeaXAJvnS1wEeA"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Iu_AkCWoEeaXAJvnS1wEeA" id="(1.0,0.7659574468085106)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Iu_AkSWoEeaXAJvnS1wEeA" id="(0.0,0.2535211267605634)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-submachineref.uml
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-submachineref.uml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Uc2AwCWmEeaXAJvnS1wEeA" name="RootElement">
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_UduxkCWmEeaXAJvnS1wEeA" name="StateMachine">
+    <nestedClassifier xmi:type="uml:Signal" xmi:id="_gMGAsCWnEeaXAJvnS1wEeA" name="E1"/>
+    <region xmi:type="uml:Region" xmi:id="_UekfECWmEeaXAJvnS1wEeA" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_PSFhMCWoEeaXAJvnS1wEeA" source="_Ny60gCWoEeaXAJvnS1wEeA" target="_Zf3OsCWmEeaXAJvnS1wEeA"/>
+      <transition xmi:type="uml:Transition" xmi:id="_QZJ28CWoEeaXAJvnS1wEeA" source="_Zf3OsCWmEeaXAJvnS1wEeA" target="_bw8ggCWmEeaXAJvnS1wEeA">
+        <trigger xmi:type="uml:Trigger" xmi:id="_SKi8ECWoEeaXAJvnS1wEeA" event="_iWfbsCWnEeaXAJvnS1wEeA"/>
+      </transition>
+      <subvertex xmi:type="uml:State" xmi:id="_Zf3OsCWmEeaXAJvnS1wEeA" name="S1"/>
+      <subvertex xmi:type="uml:State" xmi:id="_bw8ggCWmEeaXAJvnS1wEeA" name="S2" submachine="_ssBhkCWmEeaXAJvnS1wEeA"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_Ny60gCWoEeaXAJvnS1wEeA" name=""/>
+    </region>
+  </packagedElement>
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_ssBhkCWmEeaXAJvnS1wEeA" name="SubStateMachine" submachineState="_bw8ggCWmEeaXAJvnS1wEeA">
+    <nestedClassifier xmi:type="uml:Signal" xmi:id="_eLeMwCWnEeaXAJvnS1wEeA" name="E2"/>
+    <nestedClassifier xmi:type="uml:Signal" xmi:id="_-KYZYCWnEeaXAJvnS1wEeA" name="E3"/>
+    <region xmi:type="uml:Region" xmi:id="_uOEjICWmEeaXAJvnS1wEeA" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_QMMOcCWnEeaXAJvnS1wEeA" source="_N0RU0CWnEeaXAJvnS1wEeA" target="_AkYMECWnEeaXAJvnS1wEeA"/>
+      <transition xmi:type="uml:Transition" xmi:id="_IuR18CWoEeaXAJvnS1wEeA" source="_AkYMECWnEeaXAJvnS1wEeA" target="_B3idECWnEeaXAJvnS1wEeA">
+        <trigger xmi:type="uml:Trigger" xmi:id="_LaIYMCWoEeaXAJvnS1wEeA" event="_lRzWQCWnEeaXAJvnS1wEeA"/>
+      </transition>
+      <subvertex xmi:type="uml:State" xmi:id="_AkYMECWnEeaXAJvnS1wEeA" name="S20"/>
+      <subvertex xmi:type="uml:State" xmi:id="_B3idECWnEeaXAJvnS1wEeA" name="S21">
+        <region xmi:type="uml:Region" xmi:id="_FTeYcCWnEeaXAJvnS1wEeA" name="Region1">
+          <transition xmi:type="uml:Transition" xmi:id="_Q8seUCWnEeaXAJvnS1wEeA" source="_LaVpACWnEeaXAJvnS1wEeA" target="_FTg0sCWnEeaXAJvnS1wEeA"/>
+          <transition xmi:type="uml:Transition" xmi:id="_pazL8CWnEeaXAJvnS1wEeA" source="_FTg0sCWnEeaXAJvnS1wEeA" target="_IYRmMCWnEeaXAJvnS1wEeA">
+            <trigger xmi:type="uml:Trigger" xmi:id="_D17m8CWoEeaXAJvnS1wEeA" event="__1_moCWnEeaXAJvnS1wEeA"/>
+          </transition>
+          <subvertex xmi:type="uml:State" xmi:id="_FTg0sCWnEeaXAJvnS1wEeA" name="S30"/>
+          <subvertex xmi:type="uml:State" xmi:id="_IYRmMCWnEeaXAJvnS1wEeA" name="S31"/>
+          <subvertex xmi:type="uml:Pseudostate" xmi:id="_LaVpACWnEeaXAJvnS1wEeA" name=""/>
+        </region>
+      </subvertex>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_N0RU0CWnEeaXAJvnS1wEeA" name=""/>
+    </region>
+  </packagedElement>
+  <packagedElement xmi:type="uml:SignalEvent" xmi:id="_iWfbsCWnEeaXAJvnS1wEeA" name="SignalEventE1" signal="_gMGAsCWnEeaXAJvnS1wEeA"/>
+  <packagedElement xmi:type="uml:SignalEvent" xmi:id="_lRzWQCWnEeaXAJvnS1wEeA" name="SignalEventE2" signal="_eLeMwCWnEeaXAJvnS1wEeA"/>
+  <packagedElement xmi:type="uml:SignalEvent" xmi:id="__1_moCWnEeaXAJvnS1wEeA" name="SignalEventE3" signal="_-KYZYCWnEeaXAJvnS1wEeA"/>
+</uml:Model>


### PR DESCRIPTION
- This is WIP
- Enhance config and factories so that you can mix different machine types
- State can be configured as a submachine state directly by associating it with other machine.
- Few tests for UML model and annotation model.
- Different enums for machine can be used by not using `EnumStateMachineConfigurerAdapter` but pick `StateMachineConfigurerAdapter<Object, Object>` instead.