### PR TITLE
Notify transition before calling its actions

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,6 +307,12 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 				long now = System.currentTimeMillis();
 				// TODO: fix above stateContext as it's not used
 				notifyTransitionStart(buildStateContext(Stage.TRANSITION_START, message, t, getRelayStateMachine()));
+				try {
+					t.executeTransitionActions(ctx);
+				} catch (Exception e) {
+					log.warn("Aborting as transition " + t + " caused error " + e);
+					return;
+				}
 				notifyTransition(buildStateContext(Stage.TRANSITION, message, t, getRelayStateMachine()));
 				if (t.getTarget().getPseudoState() != null && t.getTarget().getPseudoState().getKind() == PseudoStateKind.JOIN) {
 					exitFromState(t.getSource(), message, t, getRelayStateMachine());

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 			try {
 				transit = t.transit(stateContext);
 			} catch (Exception e) {
-				log.warn("Transition " + t + " caused error " + e);
+				log.warn("Aborting as transition " + t + " caused error " + e);
 			}
 			if (transit) {
 				stateMachineExecutorTransit.transit(t, stateContext, queuedMessage);

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,6 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 				return false;
 			}
 		}
-		executeAllActions(context);
 		return true;
 	}
 
@@ -155,7 +154,8 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 		}
 	}
 
-	protected final void executeAllActions(StateContext<S, E> context) {
+	@Override
+	public final void executeTransitionActions(StateContext<S, E> context) {
 		if (actions == null) {
 			return;
 		}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/InitialTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/InitialTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,8 @@ public class InitialTransition<S, E> extends AbstractTransition<S, E>
 
 	@Override
 	public boolean transit(StateContext<S, E> context) {
-		executeAllActions(context);
+		// initial itself doesn't cause further changes what
+		// returned true might cause.
 		return false;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,13 @@ public interface Transition<S, E> {
 	 * @return true, if transition happened, false otherwise
 	 */
 	boolean transit(StateContext<S, E> context);
+
+	/**
+	 * Execute transition actions.
+	 *
+	 * @param context the state context
+	 */
+	void executeTransitionActions(StateContext<S, E> context);
 
 	/**
 	 * Gets the source state of this transition.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,8 +64,8 @@ public class StateContextTests extends AbstractStateMachineTests {
 		assertThat(listener.contexts, hasSize(19));
 
 		assertThat(listener.contexts, contains(
-				hasStage(Stage.EXTENDED_STATE_CHANGED),
 				hasStage(Stage.TRANSITION_START),
+				hasStage(Stage.EXTENDED_STATE_CHANGED),
 				hasStage(Stage.TRANSITION),
 				hasStage(Stage.STATE_ENTRY),
 				hasStage(Stage.TRANSITION_START),
@@ -85,15 +85,15 @@ public class StateContextTests extends AbstractStateMachineTests {
 				hasStage(Stage.TRANSITION_END)
 		));
 
-		assertThat(listener.contexts.get(0).getStage(), is(Stage.EXTENDED_STATE_CHANGED));
+		assertThat(listener.contexts.get(0).getStage(), is(Stage.TRANSITION_START));
+		assertThat(listener.contexts.get(0).getTransition(), notNullValue());
+		assertThat(listener.contexts.get(0).getTransition().getSource(), nullValue());
+		assertThat(listener.contexts.get(0).getTransition().getTarget(), notNullValue());
+		assertThat(listener.contexts.get(0).getTransition().getTarget().getId(), is(States.S0));
+		assertThat(listener.contexts.get(0).getSource(), nullValue());
+		assertThat(listener.contexts.get(0).getTarget(), notNullValue());
 
-		assertThat(listener.contexts.get(1).getStage(), is(Stage.TRANSITION_START));
-		assertThat(listener.contexts.get(1).getTransition(), notNullValue());
-		assertThat(listener.contexts.get(1).getTransition().getSource(), nullValue());
-		assertThat(listener.contexts.get(1).getTransition().getTarget(), notNullValue());
-		assertThat(listener.contexts.get(1).getTransition().getTarget().getId(), is(States.S0));
-		assertThat(listener.contexts.get(1).getSource(), nullValue());
-		assertThat(listener.contexts.get(1).getTarget(), notNullValue());
+		assertThat(listener.contexts.get(1).getStage(), is(Stage.EXTENDED_STATE_CHANGED));
 
 		assertThat(listener.contexts.get(2).getStage(), is(Stage.TRANSITION));
 		assertThat(listener.contexts.get(2).getTransition(), notNullValue());

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,6 +102,10 @@ public class StateContextExpressionMethodsTests {
 		@Override
 		public boolean transit(StateContext<SpelStates, SpelEvents> context) {
 			return false;
+		}
+
+		@Override
+		public void executeTransitionActions(StateContext<SpelStates, SpelEvents> context) {
 		}
 
 		@Override


### PR DESCRIPTION
- Add new api to Transition to expose calling
  its actions.
- Modify rest of a framework to first notify before
  calling transtion action.
- Fixes #322