### PR TITLE
Fix join dosen't enter when fork a substate

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
@@ -738,6 +738,13 @@ public abstract class AbstractStateMachineFactory<S, E> extends LifecycleObjectS
 								}
 							}
 						}
+					} else if (ss1 instanceof StateMachineState) {
+						Collection<State<S, E>> subStates = ((StateMachineState) ss1).getSubmachine().getStates();
+						for (State<S, E> subState : subStates) {
+							if (subState.getPseudoState() != null && subState.getPseudoState().getKind() == PseudoStateKind.END) {
+								joins.add(subState);
+							}
+						}
 					}
 				} else {
 					for (S fs : list) {


### PR DESCRIPTION
#337 
@jvalkeal 
Add this code at `org.springframework.statemachine.config.AbstractStateMachineFactory` to fix the problem
```
} else if (ss1 instanceof StateMachineState) {
    Collection<State<S, E>> subStates = ((StateMachineState) ss1).getSubmachine().getStates();
    for (State<S, E> subState : subStates) {
        if (subState.getPseudoState() != null && subState.getPseudoState().getKind() == PseudoStateKind.END) {
            joins.add(subState);
        }
    }
}
```