### PR TITLE
Fix action error in anonymous transition

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -29,6 +29,7 @@ import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateContext.Stage;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.StateMachineContext;
+import org.springframework.statemachine.StateMachineException;
 import org.springframework.statemachine.access.StateMachineAccess;
 import org.springframework.statemachine.access.StateMachineAccessor;
 import org.springframework.statemachine.access.StateMachineFunction;
@@ -310,8 +311,10 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 				try {
 					t.executeTransitionActions(ctx);
 				} catch (Exception e) {
+					// aborting, executor should stop possible loop checking possible transitions
+					// causing infinite execution
 					log.warn("Aborting as transition " + t + " caused error " + e);
-					return;
+					throw new StateMachineException("Aborting as transition " + t + " caused error ", e);
 				}
 				notifyTransition(buildStateContext(Stage.TRANSITION, message, t, getRelayStateMachine()));
 				if (t.getTarget().getPseudoState() != null && t.getTarget().getPseudoState().getKind() == PseudoStateKind.JOIN) {

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
@@ -243,7 +243,13 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 				log.warn("Aborting as transition " + t + " caused error " + e);
 			}
 			if (transit) {
-				stateMachineExecutorTransit.transit(t, stateContext, queuedMessage);
+				// if executor transit is raising exception, stop here
+				try {
+					stateMachineExecutorTransit.transit(t, stateContext, queuedMessage);
+				} catch (Exception e) {
+					interceptors.postTransition(stateContext);
+					return false;
+				}
 				interceptors.postTransition(stateContext);
 				break;
 			}


### PR DESCRIPTION
- Executor is following anonymous transitions in a loop
  and if there is an exception in actions with this transition,
  effectively executor ended into infinite loop.
- No bailing out from this loop if we cannot continue.
- Fixes #344