### PR TITLE
Support actions with transition via choice/junction pseudostate

### DIFF
--- a/docs/src/reference/asciidoc/sm.adoc
+++ b/docs/src/reference/asciidoc/sm.adoc
@@ -329,6 +329,23 @@ Otherwise configuration is ill-formed.
 include::samples/DocsConfigurationSampleTests.java[tags=snippetS]
 ----
 
+Actions can be executed with both incoming and outgoing transitions of
+a choice pseudostate. As seeing from below example, one dummy lambda
+action is defined leading into a choice state and one similar dummy
+lambda action defined for one outgoing transition where it also
+define an error action.
+
+[source,java,indent=0]
+----
+include::samples/DocsConfigurationSampleTests.java[tags=snippetSSS]
+----
+
+[NOTE]
+====
+Junction have same api format meaning actions can be defined
+similarly.
+====
+
 [[statemachine-config-states-junction]]
 ==== Junction State
 Junction needs to be defined in both states and transitions to work

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -653,7 +653,7 @@ public abstract class AbstractStateMachineFactory<S, E> extends LifecycleObjectS
 					if (holder.getState() == null) {
 						holderMap.put(c.getTarget(), holder);
 					}
-					choices.add(new ChoiceStateData<S, E>(holder, c.getGuard()));
+					choices.add(new ChoiceStateData<S, E>(holder, c.getGuard(), c.getActions()));
 				}
 				PseudoState<S, E> pseudoState = new ChoicePseudoState<S, E>(choices);
 				state = buildStateInternal(stateData.getState(), stateData.getDeferred(), stateData.getEntryActions(),
@@ -669,7 +669,7 @@ public abstract class AbstractStateMachineFactory<S, E> extends LifecycleObjectS
 					if (holder.getState() == null) {
 						holderMap.put(c.getTarget(), holder);
 					}
-					junctions.add(new JunctionStateData<S, E>(holder, c.getGuard()));
+					junctions.add(new JunctionStateData<S, E>(holder, c.getGuard(), c.getActions()));
 				}
 				PseudoState<S, E> pseudoState = new JunctionPseudoState<S, E>(junctions);
 				state = buildStateInternal(stateData.getState(), stateData.getDeferred(), stateData.getEntryActions(),

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ChoiceTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ChoiceTransitionConfigurer.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.statemachine.config.configurers;
 
+import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerBuilder;
 import org.springframework.statemachine.guard.Guard;
@@ -52,6 +53,35 @@ public interface ChoiceTransitionConfigurer<S, E>
 	ChoiceTransitionConfigurer<S, E> first(S target, Guard<S, E> guard);
 
 	/**
+	 * Specify a target state {@code S} as a first choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>
+	 * In normal if/else if/else this would represent if.
+	 * </p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @return configurer for chaining
+	 */
+	ChoiceTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action);
+
+	/**
+	 * Specify a target state {@code S} as a first choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>
+	 * In normal if/else if/else this would represent if.
+	 * </p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @param error action that will be called if any unexpected exception is thrown by the action.
+	 * @return configurer for chaining
+	 */
+	ChoiceTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error);
+
+	/**
 	 * Specify a target state {@code S} as a then choice.
 	 * This is optional. Multiple thens will preserve order.
 	 * <p>In normal if/else if/else this would represent else if.</p>
@@ -63,6 +93,33 @@ public interface ChoiceTransitionConfigurer<S, E>
 	ChoiceTransitionConfigurer<S, E> then(S target, Guard<S, E> guard);
 
 	/**
+	 * Specify a target state {@code S} as a then choice associating an
+	 * {@link Action} to outgoing vertex. This is optional. Multiple thens
+	 * will preserve order.
+	 * <p>In normal if/else if/else this would represent else if.</p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @return configurer for chaining
+	 */
+	ChoiceTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action);
+
+	/**
+	 * Specify a target state {@code S} as a then choice associating an
+	 * {@link Action} to outgoing vertex. This is optional. Multiple thens
+	 * will preserve order.
+	 * <p>In normal if/else if/else this would represent else if.</p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @param error action that will be called if any unexpected exception is thrown by the action.
+	 * @return configurer for chaining
+	 */
+	ChoiceTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error);
+
+	/**
 	 * Specify a target state {@code S} as a last choice.
 	 * This must be set.
 	 * <p>In normal if/else if/else this would represent else.</p>
@@ -72,4 +129,26 @@ public interface ChoiceTransitionConfigurer<S, E>
 	 */
 	ChoiceTransitionConfigurer<S, E> last(S target);
 
+	/**
+	 * Specify a target state {@code S} as a last choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>In normal if/else if/else this would represent else.</p>
+	 *
+	 * @param target the target state
+	 * @param action the action
+	 * @return configurer for chaining
+	 */
+	ChoiceTransitionConfigurer<S, E> last(S target, Action<S, E> action);
+
+	/**
+	 * Specify a target state {@code S} as a last choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>In normal if/else if/else this would represent else.</p>
+	 *
+	 * @param target the target state
+	 * @param action the action
+	 * @param error action that will be called if any unexpected exception is thrown by the action.
+	 * @return configurer for chaining
+	 */
+	ChoiceTransitionConfigurer<S, E> last(S target, Action<S, E> action, Action<S, E> error);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultChoiceTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultChoiceTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 package org.springframework.statemachine.config.configurers;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.action.Actions;
 import org.springframework.statemachine.config.builders.StateMachineTransitionBuilder;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerAdapter;
@@ -63,20 +66,61 @@ public class DefaultChoiceTransitionConfigurer<S, E>
 
 	@Override
 	public ChoiceTransitionConfigurer<S, E> first(S target, Guard<S, E> guard) {
-		this.first = new ChoiceData<S, E>(source, target, guard);
+		return first(target, guard, null);
+	}
+
+	@Override
+	public ChoiceTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action) {
+		return first(target, guard, action, null);
+	}
+
+	@Override
+	public ChoiceTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error) {
+		Collection<Action<S, E>> actions = new ArrayList<>();
+		if (action != null) {
+			actions.add(error != null ? Actions.errorCallingAction(action, error) : action);
+		}
+		this.first = new ChoiceData<S, E>(source, target, guard, actions);
 		return this;
 	}
 
 	@Override
 	public ChoiceTransitionConfigurer<S, E> then(S target, Guard<S, E> guard) {
-		thens.add(new ChoiceData<S, E>(source, target, guard));
+		return then(target, guard, null);
+	}
+
+	@Override
+	public ChoiceTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action) {
+		return then(target, guard, action, null);
+	}
+
+	@Override
+	public ChoiceTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error) {
+		Collection<Action<S, E>> actions = new ArrayList<>();
+		if (action != null) {
+			actions.add(error != null ? Actions.errorCallingAction(action, error) : action);
+		}
+		thens.add(new ChoiceData<S, E>(source, target, guard, actions));
 		return this;
 	}
 
 	@Override
 	public ChoiceTransitionConfigurer<S, E> last(S target) {
-		this.last = new ChoiceData<S, E>(source, target, null);
-		return this;
+		return last(target, null);
 	}
 
+	@Override
+	public ChoiceTransitionConfigurer<S, E> last(S target, Action<S, E> action) {
+		return last(target, action, null);
+	}
+
+	@Override
+	public ChoiceTransitionConfigurer<S, E> last(S target, Action<S, E> action, Action<S, E> error) {
+		Collection<Action<S, E>> actions = new ArrayList<>();
+		if (action != null) {
+			actions.add(error != null ? Actions.errorCallingAction(action, error) : action);
+		}
+		this.last = new ChoiceData<S, E>(source, target, null, actions);
+		return this;
+	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultJunctionTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultJunctionTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,11 @@
 package org.springframework.statemachine.config.configurers;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
+import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.action.Actions;
 import org.springframework.statemachine.config.builders.StateMachineTransitionBuilder;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerAdapter;
@@ -44,15 +47,15 @@ public class DefaultJunctionTransitionConfigurer<S, E>
 
 	@Override
 	public void configure(StateMachineTransitionBuilder<S, E> builder) throws Exception {
-		List<JunctionData<S, E>> Junctions = new ArrayList<JunctionData<S, E>>();
+		List<JunctionData<S, E>> junctions = new ArrayList<JunctionData<S, E>>();
 		if (first != null) {
-			Junctions.add(first);
+			junctions.add(first);
 		}
-		Junctions.addAll(thens);
+		junctions.addAll(thens);
 		if (last != null) {
-			Junctions.add(last);
+			junctions.add(last);
 		}
-		builder.addJunction(source, Junctions);
+		builder.addJunction(source, junctions);
 	}
 
 	@Override
@@ -63,20 +66,61 @@ public class DefaultJunctionTransitionConfigurer<S, E>
 
 	@Override
 	public JunctionTransitionConfigurer<S, E> first(S target, Guard<S, E> guard) {
-		this.first = new JunctionData<S, E>(source, target, guard);
+		return first(target, guard, null);
+	}
+
+	@Override
+	public JunctionTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action) {
+		return first(target, guard, action, null);
+	}
+
+	@Override
+	public JunctionTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error) {
+		Collection<Action<S, E>> actions = new ArrayList<>();
+		if (action != null) {
+			actions.add(error != null ? Actions.errorCallingAction(action, error) : action);
+		}
+		this.first = new JunctionData<S, E>(source, target, guard, actions);
 		return this;
 	}
 
 	@Override
 	public JunctionTransitionConfigurer<S, E> then(S target, Guard<S, E> guard) {
-		thens.add(new JunctionData<S, E>(source, target, guard));
+		return then(target, guard, null);
+	}
+
+	@Override
+	public JunctionTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action) {
+		return then(target, guard, action, null);
+	}
+
+	@Override
+	public JunctionTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error) {
+		Collection<Action<S, E>> actions = new ArrayList<>();
+		if (action != null) {
+			actions.add(error != null ? Actions.errorCallingAction(action, error) : action);
+		}
+		thens.add(new JunctionData<S, E>(source, target, guard, actions));
 		return this;
 	}
 
 	@Override
 	public JunctionTransitionConfigurer<S, E> last(S target) {
-		this.last = new JunctionData<S, E>(source, target, null);
-		return this;
+		return last(target, null);
 	}
 
+	@Override
+	public JunctionTransitionConfigurer<S, E> last(S target, Action<S, E> action) {
+		return last(target, action, null);
+	}
+
+	@Override
+	public JunctionTransitionConfigurer<S, E> last(S target, Action<S, E> action, Action<S, E> error) {
+		Collection<Action<S, E>> actions = new ArrayList<>();
+		if (action != null) {
+			actions.add(error != null ? Actions.errorCallingAction(action, error) : action);
+		}
+		this.last = new JunctionData<S, E>(source, target, null, actions);
+		return this;
+	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/JunctionTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/JunctionTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.springframework.statemachine.config.configurers;
 
+import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerBuilder;
 import org.springframework.statemachine.guard.Guard;
@@ -52,6 +53,35 @@ public interface JunctionTransitionConfigurer<S, E>
 	JunctionTransitionConfigurer<S, E> first(S target, Guard<S, E> guard);
 
 	/**
+	 * Specify a target state {@code S} as a first choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>
+	 * In normal if/else if/else this would represent if.
+	 * </p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @return configurer for chaining
+	 */
+	JunctionTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action);
+
+	/**
+	 * Specify a target state {@code S} as a first choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>
+	 * In normal if/else if/else this would represent if.
+	 * </p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @param error action that will be called if any unexpected exception is thrown by the action.
+	 * @return configurer for chaining
+	 */
+	JunctionTransitionConfigurer<S, E> first(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error);
+
+	/**
 	 * Specify a target state {@code S} as a then choice.
 	 * This is optional. Multiple thens will preserve order.
 	 * <p>In normal if/else if/else this would represent else if.</p>
@@ -63,6 +93,33 @@ public interface JunctionTransitionConfigurer<S, E>
 	JunctionTransitionConfigurer<S, E> then(S target, Guard<S, E> guard);
 
 	/**
+	 * Specify a target state {@code S} as a then choice associating an
+	 * {@link Action} to outgoing vertex. This is optional. Multiple thens
+	 * will preserve order.
+	 * <p>In normal if/else if/else this would represent else if.</p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @return configurer for chaining
+	 */
+	JunctionTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action);
+
+	/**
+	 * Specify a target state {@code S} as a then choice associating an
+	 * {@link Action} to outgoing vertex. This is optional. Multiple thens
+	 * will preserve order.
+	 * <p>In normal if/else if/else this would represent else if.</p>
+	 *
+	 * @param target the target state
+	 * @param guard the guard for this choice
+	 * @param action the action
+	 * @param error action that will be called if any unexpected exception is thrown by the action.
+	 * @return configurer for chaining
+	 */
+	JunctionTransitionConfigurer<S, E> then(S target, Guard<S, E> guard, Action<S, E> action, Action<S, E> error);
+
+	/**
 	 * Specify a target state {@code S} as a last choice.
 	 * This must be set.
 	 * <p>In normal if/else if/else this would represent else.</p>
@@ -71,5 +128,28 @@ public interface JunctionTransitionConfigurer<S, E>
 	 * @return configurer for chaining
 	 */
 	JunctionTransitionConfigurer<S, E> last(S target);
+
+	/**
+	 * Specify a target state {@code S} as a last choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>In normal if/else if/else this would represent else.</p>
+	 *
+	 * @param target the target state
+	 * @param action the action
+	 * @return configurer for chaining
+	 */
+	JunctionTransitionConfigurer<S, E> last(S target, Action<S, E> action);
+
+	/**
+	 * Specify a target state {@code S} as a last choice associating an
+	 * {@link Action} to outgoing vertex. This must be set.
+	 * <p>In normal if/else if/else this would represent else.</p>
+	 *
+	 * @param target the target state
+	 * @param action the action
+	 * @param error action that will be called if any unexpected exception is thrown by the action.
+	 * @return configurer for chaining
+	 */
+	JunctionTransitionConfigurer<S, E> last(S target, Action<S, E> action, Action<S, E> error);
 
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ChoiceData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ChoiceData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.statemachine.config.model;
 
+import java.util.Collection;
+
+import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.guard.Guard;
 
 /**
@@ -27,6 +30,7 @@ public class ChoiceData<S, E> {
 	private final S source;
 	private final S target;
 	private final Guard<S, E> guard;
+	private final Collection<Action<S, E>> actions;
 
 	/**
 	 * Instantiates a new choice data.
@@ -36,9 +40,22 @@ public class ChoiceData<S, E> {
 	 * @param guard the guard
 	 */
 	public ChoiceData(S source, S target, Guard<S, E> guard) {
+		this(source, target, guard, null);
+	}
+
+	/**
+	 * Instantiates a new choice data.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param guard the guard
+	 * @param actions the actions
+	 */
+	public ChoiceData(S source, S target, Guard<S, E> guard, Collection<Action<S, E>> actions) {
 		this.source = source;
 		this.target = target;
 		this.guard = guard;
+		this.actions = actions;
 	}
 
 	/**
@@ -66,5 +83,14 @@ public class ChoiceData<S, E> {
 	 */
 	public Guard<S, E> getGuard() {
 		return guard;
+	}
+
+	/**
+	 * Gets the actions.
+	 *
+	 * @return the actions
+	 */
+	public Collection<Action<S, E>> getActions() {
+		return actions;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/JunctionData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/JunctionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.statemachine.config.model;
 
+import java.util.Collection;
+
+import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.guard.Guard;
 
 /**
@@ -27,6 +30,7 @@ public class JunctionData<S, E> {
 	private final S source;
 	private final S target;
 	private final Guard<S, E> guard;
+	private final Collection<Action<S, E>> actions;
 
 	/**
 	 * Instantiates a new junction data.
@@ -36,9 +40,22 @@ public class JunctionData<S, E> {
 	 * @param guard the guard
 	 */
 	public JunctionData(S source, S target, Guard<S, E> guard) {
+		this(source, target, guard, null);
+	}
+
+	/**
+	 * Instantiates a new junction data.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param guard the guard
+	 * @param actions the actions
+	 */
+	public JunctionData(S source, S target, Guard<S, E> guard, Collection<Action<S, E>> actions) {
 		this.source = source;
 		this.target = target;
 		this.guard = guard;
+		this.actions = actions;
 	}
 
 	/**
@@ -66,5 +83,14 @@ public class JunctionData<S, E> {
 	 */
 	public Guard<S, E> getGuard() {
 		return guard;
+	}
+
+	/**
+	 * Gets the actions.
+	 *
+	 * @return the actions
+	 */
+	public Collection<Action<S, E>> getActions() {
+		return actions;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/ChoicePseudoState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/ChoicePseudoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,13 @@
  */
 package org.springframework.statemachine.state;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.guard.Guard;
 import org.springframework.util.Assert;
 
@@ -53,11 +55,16 @@ public class ChoicePseudoState<S, E> implements PseudoState<S, E> {
 	@Override
 	public State<S, E> entry(StateContext<S, E> context) {
 		State<S, E> s = null;
+		ChoiceStateData<S, E> csd = null;
 		for (ChoiceStateData<S, E> c : choices) {
-			s = c.getState();
+			csd = c;
 			if (c.guard != null && evaluateInternal(c.guard, context)) {
 				break;
 			}
+		}
+		if (csd != null) {
+			s = csd.getState();
+			executeActions(csd.getActions(), context);
 		}
 		return s;
 	}
@@ -83,6 +90,19 @@ public class ChoicePseudoState<S, E> implements PseudoState<S, E> {
 		}
 	}
 
+	private void executeActions(Collection<Action<S, E>> actions, StateContext<S, E> context) {
+		if (actions == null) {
+			return;
+		}
+		for (Action<S, E> action : actions) {
+			try {
+				action.execute(context);
+			} catch (Throwable t) {
+				log.warn("Action execution resulted error", t);
+			}
+		}
+	}
+
 	/**
 	 * Data class wrapping choice {@link State} and {@link Guard}
 	 * together.
@@ -93,17 +113,20 @@ public class ChoicePseudoState<S, E> implements PseudoState<S, E> {
 	public static class ChoiceStateData<S, E> {
 		private final StateHolder<S, E> state;
 		private final Guard<S, E> guard;
+		private final Collection<Action<S, E>> actions;
 
 		/**
 		 * Instantiates a new choice state data.
 		 *
 		 * @param state the state holder
 		 * @param guard the guard
+		 * @param actions the actions
 		 */
-		public ChoiceStateData(StateHolder<S, E> state, Guard<S, E> guard) {
+		public ChoiceStateData(StateHolder<S, E> state, Guard<S, E> guard, Collection<Action<S, E>> actions) {
 			Assert.notNull(state, "Holder must be set");
 			this.state = state;
 			this.guard = guard;
+			this.actions = actions;
 		}
 
 		/**
@@ -131,6 +154,15 @@ public class ChoicePseudoState<S, E> implements PseudoState<S, E> {
 		 */
 		public Guard<S, E> getGuard() {
 			return guard;
+		}
+
+		/**
+		 * Gets the actions.
+		 *
+		 * @return the actions
+		 */
+		public Collection<Action<S, E>> getActions() {
+			return actions;
 		}
 	}
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests.java
@@ -747,6 +747,48 @@ public class DocsConfigurationSampleTests extends AbstractStateMachineTests {
 	}
 // end::snippetS[]
 
+// tag::snippetSSS[]
+	@Configuration
+	@EnableStateMachine
+	public class Config23
+			extends EnumStateMachineConfigurerAdapter<States, Events> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<States, Events> states)
+				throws Exception {
+			states
+				.withStates()
+					.initial(States.SI)
+					.choice(States.S1)
+					.end(States.SF)
+					.states(EnumSet.allOf(States.class));
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<States, Events> transitions)
+				throws Exception {
+			transitions
+				.withExternal()
+					.source(States.SI)
+					.action(c -> {
+							// action with SI-S1
+						})
+					.target(States.S1)
+					.and()
+				.withChoice()
+					.source(States.S1)
+					.first(States.S2, c -> {
+							return true;
+						})
+					.last(States.S3, c -> {
+							// action with S1-S3
+						}, c -> {
+							// error callback for action S1-S3
+						});
+		}
+	}
+// end::snippetSSS[]
+
 // tag::snippetSS[]
 		@Configuration
 		@EnableStateMachine

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JunctionStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JunctionStateTests.java
@@ -16,10 +16,13 @@
 package org.springframework.statemachine.state;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import java.util.EnumSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -30,6 +33,7 @@ import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.ObjectStateMachine;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachineSystemConstants;
+import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
@@ -126,6 +130,44 @@ public class JunctionStateTests extends AbstractStateMachineTests {
 		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).setHeader("junction", "s2").build());
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S21));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testTransitionToJunctionActionCalled1() throws InterruptedException {
+		context.register(Config4.class);
+		context.refresh();
+		ObjectStateMachine<TestStates,TestEvents> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, ObjectStateMachine.class);
+		LatchAction sIToJunction = context.getBean("sIToJunction", LatchAction.class);
+		LatchAction junctionToS30 = context.getBean("junctionToS30", LatchAction.class);
+		LatchAction junctionToS33 = context.getBean("junctionToS33", LatchAction.class);
+		assertThat(machine, notNullValue());
+		machine.start();
+		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).setHeader("junction", "s30").build());
+		assertThat(sIToJunction.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(junctionToS30.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(junctionToS33.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(machine.getState().getIds(), contains(TestStates.S30));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testTransitionToJunctionActionCalled2() throws InterruptedException {
+		context.register(Config4.class);
+		context.refresh();
+		ObjectStateMachine<TestStates,TestEvents> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, ObjectStateMachine.class);
+		LatchAction sIToJunction = context.getBean("sIToJunction", LatchAction.class);
+		LatchAction junctionToS30 = context.getBean("junctionToS30", LatchAction.class);
+		LatchAction junctionToS33 = context.getBean("junctionToS33", LatchAction.class);
+		assertThat(machine, notNullValue());
+		machine.start();
+		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		assertThat(sIToJunction.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(junctionToS30.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(junctionToS33.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(machine.getState().getIds(), contains(TestStates.S33));
 	}
 
 	@Configuration
@@ -264,6 +306,73 @@ public class JunctionStateTests extends AbstractStateMachineTests {
 		}
 	}
 
+	@Configuration
+	@EnableStateMachine
+	static class Config4 extends EnumStateMachineConfigurerAdapter<TestStates, TestEvents> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<TestStates, TestEvents> states) throws Exception {
+			states
+				.withStates()
+					.initial(TestStates.SI)
+					.states(EnumSet.allOf(TestStates.class))
+					.junction(TestStates.S3)
+					.end(TestStates.SF);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<TestStates, TestEvents> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(TestStates.SI)
+					.target(TestStates.S3)
+					.action(sIToJunction())
+					.event(TestEvents.E1)
+					.and()
+				.withJunction()
+					.source(TestStates.S3)
+					.first(TestStates.S30, s30Guard(), junctionToS30())
+					.then(TestStates.S31, s31Guard())
+					.then(TestStates.S32, s32Guard())
+					.last(TestStates.S33, junctionToS33(), junctionToS33Error());
+		}
+
+		@Bean
+		public Guard<TestStates, TestEvents> s30Guard() {
+			return new JunctionGuard("s30");
+		}
+
+		@Bean
+		public Guard<TestStates, TestEvents> s31Guard() {
+			return new JunctionGuard("s31");
+		}
+
+		@Bean
+		public Guard<TestStates, TestEvents> s32Guard() {
+			return new JunctionGuard("s32");
+		}
+
+		@Bean
+		public Action<TestStates, TestEvents> sIToJunction() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public Action<TestStates, TestEvents> junctionToS30() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public Action<TestStates, TestEvents> junctionToS33() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public Action<TestStates, TestEvents> junctionToS33Error() {
+			return new LatchAction();
+		}
+	}
+
 	private static class JunctionGuard implements Guard<TestStates, TestEvents> {
 
 		private final String match;
@@ -278,4 +387,12 @@ public class JunctionStateTests extends AbstractStateMachineTests {
 		}
 	}
 
+	private static class LatchAction implements Action<TestStates, TestEvents> {
+		CountDownLatch latch = new CountDownLatch(1);
+
+		@Override
+		public void execute(StateContext<TestStates, TestEvents> context) {
+			latch.countDown();
+		}
+	}
 }

--- a/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
+++ b/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -288,11 +288,12 @@ public class UmlModelParser {
 						choices.put(transition.getSource().getName(), list);
 					}
 					Guard<String, String> guard = resolveGuard(transition);
+					Collection<Action<String,String>> actions = UmlUtils.resolveTransitionActions(transition, resolver);
 					// we want null guards to be at the end
 					if (guard == null) {
-						list.addLast(new ChoiceData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard));
+						list.addLast(new ChoiceData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard, actions));
 					} else {
-						list.addFirst(new ChoiceData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard));
+						list.addFirst(new ChoiceData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard, actions));
 					}
 				} else if (((Pseudostate)transition.getSource()).getKind() == PseudostateKind.JUNCTION_LITERAL) {
 					LinkedList<JunctionData<String, String>> list = junctions.get(transition.getSource().getName());
@@ -301,11 +302,12 @@ public class UmlModelParser {
 						junctions.put(transition.getSource().getName(), list);
 					}
 					Guard<String, String> guard = resolveGuard(transition);
+					Collection<Action<String,String>> actions = UmlUtils.resolveTransitionActions(transition, resolver);
 					// we want null guards to be at the end
 					if (guard == null) {
-						list.addLast(new JunctionData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard));
+						list.addLast(new JunctionData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard, actions));
 					} else {
-						list.addFirst(new JunctionData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard));
+						list.addFirst(new JunctionData<String, String>(transition.getSource().getName(), transition.getTarget().getName(), guard, actions));
 					}
 				} else if (((Pseudostate)transition.getSource()).getKind() == PseudostateKind.FORK_LITERAL) {
 					List<String> list = forks.get(transition.getSource().getName());

--- a/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
+++ b/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -926,6 +926,144 @@ public class UmlStateMachineModelFactoryTests extends AbstractUmlTests {
 		assertThat(stateMachineModel.getTransitionsData().getExits().size(), is(1));
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testActionWithTransitionChoice1() throws InterruptedException {
+		context.register(Config25.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+
+		LatchAction s1ToChoice = context.getBean("s1ToChoice", LatchAction.class);
+		LatchAction choiceToS2 = context.getBean("choiceToS2", LatchAction.class);
+		LatchAction choiceToS4 = context.getBean("choiceToS4", LatchAction.class);
+
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent(MessageBuilder.withPayload("E1").setHeader("choice", "s2").build());
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2"));
+
+		assertThat(s1ToChoice.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS2.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS4.latch.await(1, TimeUnit.SECONDS), is(false));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testActionWithTransitionChoice2() throws InterruptedException {
+		context.register(Config25.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+
+		LatchAction s1ToChoice = context.getBean("s1ToChoice", LatchAction.class);
+		LatchAction choiceToS2 = context.getBean("choiceToS2", LatchAction.class);
+		LatchAction choiceToS4 = context.getBean("choiceToS4", LatchAction.class);
+
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent(MessageBuilder.withPayload("E1").build());
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S4"));
+
+		assertThat(s1ToChoice.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS2.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choiceToS4.latch.await(1, TimeUnit.SECONDS), is(true));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testActionWithTransitionChoice3() throws InterruptedException {
+		context.register(Config25.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+
+		LatchAction s1ToChoice = context.getBean("s1ToChoice", LatchAction.class);
+		LatchAction choiceToS2 = context.getBean("choiceToS2", LatchAction.class);
+		LatchAction choiceToS4 = context.getBean("choiceToS4", LatchAction.class);
+		LatchAction choice1ToChoice2 = context.getBean("choice1ToChoice2", LatchAction.class);
+		LatchAction choiceToS5 = context.getBean("choiceToS5", LatchAction.class);
+		LatchAction choiceToS6 = context.getBean("choiceToS6", LatchAction.class);
+
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent(MessageBuilder.withPayload("E1").setHeader("choice", "choice2").build());
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S6"));
+
+		assertThat(s1ToChoice.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS2.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choiceToS4.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choice1ToChoice2.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS5.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choiceToS6.latch.await(1, TimeUnit.SECONDS), is(true));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testActionWithTransitionJunction1() throws InterruptedException {
+		context.register(Config26.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+
+		LatchAction s1ToChoice = context.getBean("s1ToChoice", LatchAction.class);
+		LatchAction choiceToS2 = context.getBean("choiceToS2", LatchAction.class);
+		LatchAction choiceToS4 = context.getBean("choiceToS4", LatchAction.class);
+
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent(MessageBuilder.withPayload("E1").setHeader("choice", "s2").build());
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2"));
+
+		assertThat(s1ToChoice.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS2.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS4.latch.await(1, TimeUnit.SECONDS), is(false));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testActionWithTransitionJunction2() throws InterruptedException {
+		context.register(Config26.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+
+		LatchAction s1ToChoice = context.getBean("s1ToChoice", LatchAction.class);
+		LatchAction choiceToS2 = context.getBean("choiceToS2", LatchAction.class);
+		LatchAction choiceToS4 = context.getBean("choiceToS4", LatchAction.class);
+
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent(MessageBuilder.withPayload("E1").build());
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S4"));
+
+		assertThat(s1ToChoice.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS2.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choiceToS4.latch.await(1, TimeUnit.SECONDS), is(true));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testActionWithTransitionJunction3() throws InterruptedException {
+		context.register(Config26.class);
+		context.refresh();
+		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+
+		LatchAction s1ToChoice = context.getBean("s1ToChoice", LatchAction.class);
+		LatchAction choiceToS2 = context.getBean("choiceToS2", LatchAction.class);
+		LatchAction choiceToS4 = context.getBean("choiceToS4", LatchAction.class);
+		LatchAction choice1ToChoice2 = context.getBean("choice1ToChoice2", LatchAction.class);
+		LatchAction choiceToS5 = context.getBean("choiceToS5", LatchAction.class);
+		LatchAction choiceToS6 = context.getBean("choiceToS6", LatchAction.class);
+
+		stateMachine.start();
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
+		stateMachine.sendEvent(MessageBuilder.withPayload("E1").setHeader("choice", "choice2").build());
+		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S6"));
+
+		assertThat(s1ToChoice.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS2.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choiceToS4.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choice1ToChoice2.latch.await(1, TimeUnit.SECONDS), is(true));
+		assertThat(choiceToS5.latch.await(1, TimeUnit.SECONDS), is(false));
+		assertThat(choiceToS6.latch.await(1, TimeUnit.SECONDS), is(true));
+	}
+
 	@Configuration
 	@EnableStateMachine
 	public static class Config2 extends StateMachineConfigurerAdapter<String, String> {
@@ -1396,6 +1534,143 @@ public class UmlStateMachineModelFactoryTests extends AbstractUmlTests {
 			Resource model = new ClassPathResource("org/springframework/statemachine/uml/simple-connectionpointref.uml");
 			return new UmlStateMachineModelFactory(model);
 		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	public static class Config25 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineModelConfigurer<String, String> model) throws Exception {
+			model
+				.withModel()
+					.factory(modelFactory());
+		}
+
+		@Bean
+		public StateMachineModelFactory<String, String> modelFactory() {
+			Resource model = new ClassPathResource("org/springframework/statemachine/uml/action-with-transition-choice.uml");
+			return new UmlStateMachineModelFactory(model);
+		}
+
+		@Bean
+		public ChoiceGuard s2Guard() {
+			return new ChoiceGuard("s2");
+		}
+
+		@Bean
+		public ChoiceGuard s3Guard() {
+			return new ChoiceGuard("s3");
+		}
+
+		@Bean
+		public ChoiceGuard s5Guard() {
+			return new ChoiceGuard("s5");
+		}
+
+		@Bean
+		public ChoiceGuard choice2Guard() {
+			return new ChoiceGuard("choice2");
+		}
+
+		@Bean
+		public LatchAction s1ToChoice() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS2() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS4() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choice1ToChoice2() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS5() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS6() {
+			return new LatchAction();
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	public static class Config26 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineModelConfigurer<String, String> model) throws Exception {
+			model
+				.withModel()
+					.factory(modelFactory());
+		}
+
+		@Bean
+		public StateMachineModelFactory<String, String> modelFactory() {
+			Resource model = new ClassPathResource("org/springframework/statemachine/uml/action-with-transition-junction.uml");
+			return new UmlStateMachineModelFactory(model);
+		}
+
+		@Bean
+		public ChoiceGuard s2Guard() {
+			return new ChoiceGuard("s2");
+		}
+
+		@Bean
+		public ChoiceGuard s3Guard() {
+			return new ChoiceGuard("s3");
+		}
+
+		@Bean
+		public ChoiceGuard s5Guard() {
+			return new ChoiceGuard("s5");
+		}
+
+		@Bean
+		public ChoiceGuard choice2Guard() {
+			return new ChoiceGuard("choice2");
+		}
+
+		@Bean
+		public LatchAction s1ToChoice() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS2() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS4() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choice1ToChoice2() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS5() {
+			return new LatchAction();
+		}
+
+		@Bean
+		public LatchAction choiceToS6() {
+			return new LatchAction();
+		}
+
 	}
 
 	public static class LatchAction implements Action<String, String> {

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-choice.di
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-choice.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-choice.notation
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-choice.notation
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_OrqPAAOpEeaiNLSABY7wHw" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_OrqPAQOpEeaiNLSABY7wHw" type="2000">
+    <children xmi:type="notation:DecorationNode" xmi:id="_OrqPAgOpEeaiNLSABY7wHw" type="2001">
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPAwOpEeaiNLSABY7wHw" width="831" height="23"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_OrqPBAOpEeaiNLSABY7wHw" type="2002">
+      <children xmi:type="notation:Shape" xmi:id="_OrqPBQOpEeaiNLSABY7wHw" type="3000">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OrqPBgOpEeaiNLSABY7wHw" source="RegionAnnotationKey">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OrqPBwOpEeaiNLSABY7wHw" key="RegionZoneKey" value=""/>
+        </eAnnotations>
+        <children xmi:type="notation:DecorationNode" xmi:id="_OrqPCAOpEeaiNLSABY7wHw" type="3002">
+          <children xmi:type="notation:Shape" xmi:id="_e6i4cAOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_e6i4cgOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOQNwAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_e6jfgAOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_e6jfgQOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_e6jfggOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e6jfgwOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-choice.uml#_e6aVkAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e6i4cQOpEeaiNLSABY7wHw" x="110" y="107" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_fyMSIAOpEeaiNLSABY7wHw" type="8000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_fyM5MAOpEeaiNLSABY7wHw" type="8001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_fyM5MQOpEeaiNLSABY7wHw" x="25" y="3"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_fyM5MgOpEeaiNLSABY7wHw" type="8002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_fyM5MwOpEeaiNLSABY7wHw" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="action-with-transition-choice.uml#_fyGykAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fyMSIQOpEeaiNLSABY7wHw" x="30" y="107"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_hTbbYAOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_hTbbYgOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ln3FAAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hTbbYwOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_hTbbZAOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hTbbZQOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hTbbZgOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-choice.uml#_hTUGoAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hTbbYQOpEeaiNLSABY7wHw" x="490" y="27" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_hwzT4AOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_hwzT4gOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ln3sEAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hwzT4wOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_hwzT5AOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hwzT5QOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwzT5gOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-choice.uml#_hwr_IAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwzT4QOpEeaiNLSABY7wHw" x="490" y="87" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_in_akAOpEeaiNLSABY7wHw" type="11000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_ioABoAOpEeaiNLSABY7wHw" type="11001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ioABoQOpEeaiNLSABY7wHw" x="-60" y="-20"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_ioABogOpEeaiNLSABY7wHw" type="11002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_ioABowOpEeaiNLSABY7wHw" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="action-with-transition-choice.uml#_in3ewAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_in_akQOpEeaiNLSABY7wHw" x="250" y="107"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_1gApcAOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_1gBQgAOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3uzcQAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_1gBQgQOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_1gBQggOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_1gBQgwOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gBQhAOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-choice.uml#_1f3fgAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gApcQOpEeaiNLSABY7wHw" x="110" y="227" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="__xK8oDFnEeeP8_MeAypGlA" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="__xLjsDFnEeeP8_MeAypGlA" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BCpLkDFoEeeP8_MeAypGlA" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="__xLjsTFnEeeP8_MeAypGlA" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="__xLjsjFnEeeP8_MeAypGlA" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="__xLjszFnEeeP8_MeAypGlA" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xLjtDFnEeeP8_MeAypGlA" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-choice.uml#__wwF4DFnEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xK8oTFnEeeP8_MeAypGlA" x="650" y="207" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_B94EwDFoEeeP8_MeAypGlA" type="11000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_B94EwjFoEeeP8_MeAypGlA" type="11001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B94EwzFoEeeP8_MeAypGlA" x="-76"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_B94ExDFoEeeP8_MeAypGlA" type="11002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_B94ExTFoEeeP8_MeAypGlA" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="action-with-transition-choice.uml#_B9rQcDFoEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_B94EwTFoEeeP8_MeAypGlA" x="426" y="207"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_FQwKwDFoEeeP8_MeAypGlA" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_FQwKwjFoEeeP8_MeAypGlA" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GR_lUDFoEeeP8_MeAypGlA" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_FQwKwzFoEeeP8_MeAypGlA" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_FQwKxDFoEeeP8_MeAypGlA" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_FQwx0DFoEeeP8_MeAypGlA" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FQwx0TFoEeeP8_MeAypGlA" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-choice.uml#_FQg6MDFoEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FQwKwTFoEeeP8_MeAypGlA" x="650" y="307" width="83"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPCQOpEeaiNLSABY7wHw"/>
+        </children>
+        <element xmi:type="uml:Region" href="action-with-transition-choice.uml#_OrpA4AOpEeaiNLSABY7wHw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPCgOpEeaiNLSABY7wHw" width="831" height="388"/>
+      </children>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPCwOpEeaiNLSABY7wHw" y="23" width="831" height="388"/>
+    </children>
+    <element xmi:type="uml:StateMachine" href="action-with-transition-choice.uml#_OrcMkAOpEeaiNLSABY7wHw"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPDAOpEeaiNLSABY7wHw" x="30" y="30" width="831" height="411"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_OrqPDQOpEeaiNLSABY7wHw" name="diagram_compatibility_version" stringValue="1.1.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_OrqPDgOpEeaiNLSABY7wHw"/>
+  <styles xmi:type="style:PapyrusViewStyle" xmi:id="_OrqPDwOpEeaiNLSABY7wHw">
+    <owner xmi:type="uml:Model" href="action-with-transition-choice.uml#_OqqwgAOpEeaiNLSABY7wHw"/>
+  </styles>
+  <element xmi:type="uml:StateMachine" href="action-with-transition-choice.uml#_OrcMkAOpEeaiNLSABY7wHw"/>
+  <edges xmi:type="notation:Connector" xmi:id="_7ZbT4AOpEeaiNLSABY7wHw" type="7000" source="_fyMSIAOpEeaiNLSABY7wHw" target="_e6i4cAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_7Zb68AOpEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_7Zb68QOpEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_7Zb68gOpEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_7Zb68wOpEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_7Zb69AOpEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_7Zb69QOpEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_7ZbT4QOpEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_7V6s4AOpEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7ZbT4gOpEeaiNLSABY7wHw" points="[8, -4, -123, 0]$[130, -10, -1, -6]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aHQYAOpEeaiNLSABY7wHw" id="(1.0,0.5)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aH3cAOpEeaiNLSABY7wHw" id="(0.0,0.14893617021276595)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_X0QVwAOqEeaiNLSABY7wHw" type="7000" source="_e6i4cAOpEeaiNLSABY7wHw" target="_in_akAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_X0Q80AOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_X0Q80QOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_X0Q80gOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_X0Q80wOqEeaiNLSABY7wHw" x="10" y="17"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_X0Q81AOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_X0Q81QOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_X0QVwQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_X0EvkAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X0QVwgOqEeaiNLSABY7wHw" points="[5, 0, -89, -10]$[86, 10, -8, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X0wsEAOqEeaiNLSABY7wHw" id="(1.0,0.44680851063829785)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X0wsEQOqEeaiNLSABY7wHw" id="(0.0,0.45)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ar9isAOqEeaiNLSABY7wHw" type="7000" source="_in_akAOpEeaiNLSABY7wHw" target="_hTbbYAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_ar-JwAOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_ar-JwQOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_ar-JwgOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_ar-JwwOqEeaiNLSABY7wHw" x="-10" y="-16"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_ar-JxAOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_ar-JxQOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_ar9isQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_arx8gAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ar9isgOqEeaiNLSABY7wHw" points="[-6, 3, -220, 58]$[-6, -55, -220, 0]$[214, -55, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ascq4AOqEeaiNLSABY7wHw" id="(0.43333333333333335,0.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ascq4QOqEeaiNLSABY7wHw" id="(0.0,0.5319148936170213)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_bfppcAOqEeaiNLSABY7wHw" type="7000" source="_in_akAOpEeaiNLSABY7wHw" target="_hwzT4AOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_bfppcwOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_bfppdAOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_bfppdQOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_bfppdgOqEeaiNLSABY7wHw" x="10" y="-22"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_bfqQgAOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_bfqQgQOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_bfppcQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_bfbnAAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bfppcgOqEeaiNLSABY7wHw" points="[20, 3, -90, 13]$[144, 37, 34, 47]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bgNqIAOqEeaiNLSABY7wHw" id="(1.0,0.75)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bgNqIQOqEeaiNLSABY7wHw" id="(0.0,0.574468085106383)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_cJG2IAOqEeaiNLSABY7wHw" type="7000" source="_in_akAOpEeaiNLSABY7wHw" target="_1gApcAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_cJG2IwOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_cJHdMAOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_cJHdMQOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_cJHdMgOqEeaiNLSABY7wHw" x="2" y="-14"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_cJHdMwOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_cJHdNAOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_cJG2IQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_cIytEAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cJG2IgOqEeaiNLSABY7wHw" points="[0, -4, 77, -139]$[0, 135, 77, 0]$[-77, 135, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cJvIQAOqEeaiNLSABY7wHw" id="(0.3333333333333333,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cJvvUAOqEeaiNLSABY7wHw" id="(1.0,0.7446808510638298)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_JwVUcDFoEeeP8_MeAypGlA" type="7000" source="_in_akAOpEeaiNLSABY7wHw" target="_B94EwDFoEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_JwVUczFoEeeP8_MeAypGlA" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_JwVUdDFoEeeP8_MeAypGlA"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_JwVUdTFoEeeP8_MeAypGlA" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_JwVUdjFoEeeP8_MeAypGlA" x="60" y="-40"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_JwVUdzFoEeeP8_MeAypGlA" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_JwVUeDFoEeeP8_MeAypGlA" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_JwVUcTFoEeeP8_MeAypGlA"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_Jv-vIDFoEeeP8_MeAypGlA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JwVUcjFoEeeP8_MeAypGlA" points="[11, 6, -171, -88]$[183, 92, 1, -2]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JxAC0DFoEeeP8_MeAypGlA" id="(0.9166666666666666,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JxAC0TFoEeeP8_MeAypGlA" id="(0.4666666666666667,0.0)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_K29lUDFoEeeP8_MeAypGlA" type="7000" source="_B94EwDFoEeeP8_MeAypGlA" target="__xK8oDFnEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_K29lUzFoEeeP8_MeAypGlA" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_K29lVDFoEeeP8_MeAypGlA"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_K29lVTFoEeeP8_MeAypGlA" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_K29lVjFoEeeP8_MeAypGlA" x="5" y="-23"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_K29lVzFoEeeP8_MeAypGlA" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_K29lWDFoEeeP8_MeAypGlA" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_K29lUTFoEeeP8_MeAypGlA"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_K2u70DFoEeeP8_MeAypGlA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K29lUjFoEeeP8_MeAypGlA" points="[2, 0, -181, -15]$[175, 14, -8, -1]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3kCQDFoEeeP8_MeAypGlA" id="(1.0,0.35)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3kCQTFoEeeP8_MeAypGlA" id="(0.0,0.44680851063829785)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_LqcQsDFoEeeP8_MeAypGlA" type="7000" source="_B94EwDFoEeeP8_MeAypGlA" target="_FQwKwDFoEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_LqcQszFoEeeP8_MeAypGlA" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Lqc3wDFoEeeP8_MeAypGlA"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_Lqc3wTFoEeeP8_MeAypGlA" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Lqc3wjFoEeeP8_MeAypGlA" x="39" y="-12"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_Lqc3wzFoEeeP8_MeAypGlA" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Lqc3xDFoEeeP8_MeAypGlA" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_LqcQsTFoEeeP8_MeAypGlA"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-choice.uml#_LqOOQDFoEeeP8_MeAypGlA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LqcQsjFoEeeP8_MeAypGlA" points="[11, 6, -199, -102]$[194, 104, -16, -4]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LrD7wDFoEeeP8_MeAypGlA" id="(0.7666666666666667,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LrD7wTFoEeeP8_MeAypGlA" id="(0.0,0.19148936170212766)"/>
+  </edges>
+</notation:Diagram>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-choice.uml
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-choice.uml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_OqqwgAOpEeaiNLSABY7wHw" name="RootElement">
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_OrcMkAOpEeaiNLSABY7wHw" name="StateMachine">
+    <region xmi:type="uml:Region" xmi:id="_OrpA4AOpEeaiNLSABY7wHw" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_7V6s4AOpEeaiNLSABY7wHw" source="_fyGykAOpEeaiNLSABY7wHw" target="_e6aVkAOpEeaiNLSABY7wHw"/>
+      <transition xmi:type="uml:Transition" xmi:id="_X0EvkAOqEeaiNLSABY7wHw" source="_e6aVkAOpEeaiNLSABY7wHw" target="_in3ewAOpEeaiNLSABY7wHw">
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_AKBlwDCdEeeP8_MeAypGlA" name="s1ToChoice">
+          <language>bean</language>
+          <body>s1ToChoice</body>
+        </effect>
+        <trigger xmi:type="uml:Trigger" xmi:id="_CVbtoAOzEeaiNLSABY7wHw" event="_9sMRoAOyEeaiNLSABY7wHw"/>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_arx8gAOqEeaiNLSABY7wHw" guard="_yT_ckAOtEeaiNLSABY7wHw" source="_in3ewAOpEeaiNLSABY7wHw" target="_hTUGoAOpEeaiNLSABY7wHw">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_yT_ckAOtEeaiNLSABY7wHw">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_yT_ckQOtEeaiNLSABY7wHw">
+            <language>bean</language>
+            <body>s2Guard</body>
+          </specification>
+        </ownedRule>
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_IDAUMDCdEeeP8_MeAypGlA" name="choiceToS2">
+          <language>bean</language>
+          <body>choiceToS2</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_bfbnAAOqEeaiNLSABY7wHw" guard="_9yVIIAOtEeaiNLSABY7wHw" source="_in3ewAOpEeaiNLSABY7wHw" target="_hwr_IAOpEeaiNLSABY7wHw">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_9yVIIAOtEeaiNLSABY7wHw">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_9yVIIQOtEeaiNLSABY7wHw">
+            <language>bean</language>
+            <body>s3Guard</body>
+          </specification>
+        </ownedRule>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_cIytEAOqEeaiNLSABY7wHw" source="_in3ewAOpEeaiNLSABY7wHw" target="_1f3fgAOpEeaiNLSABY7wHw">
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_LR1AoDCdEeeP8_MeAypGlA" name="choiceToS4">
+          <language>bean</language>
+          <body>choiceToS4</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_Jv-vIDFoEeeP8_MeAypGlA" guard="_UnE0gDFoEeeP8_MeAypGlA" source="_in3ewAOpEeaiNLSABY7wHw" target="_B9rQcDFoEeeP8_MeAypGlA">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_UnE0gDFoEeeP8_MeAypGlA">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_UnE0gTFoEeeP8_MeAypGlA" name="choice2Guard">
+            <language>bean</language>
+            <body>choice2Guard</body>
+          </specification>
+        </ownedRule>
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_q79L0DFoEeeP8_MeAypGlA" name="choice1ToChoice2">
+          <language>bean</language>
+          <body>choice1ToChoice2</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_K2u70DFoEeeP8_MeAypGlA" guard="_aQIHsDFoEeeP8_MeAypGlA" source="_B9rQcDFoEeeP8_MeAypGlA" target="__wwF4DFnEeeP8_MeAypGlA">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_aQIHsDFoEeeP8_MeAypGlA">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_aQIHsTFoEeeP8_MeAypGlA" name="s5Guard">
+            <language>bean</language>
+            <body>s5Guard</body>
+          </specification>
+        </ownedRule>
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_POtMMDFpEeeP8_MeAypGlA" name="choiceToS5">
+          <language>bean</language>
+          <body>choiceToS5</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_LqOOQDFoEeeP8_MeAypGlA" source="_B9rQcDFoEeeP8_MeAypGlA" target="_FQg6MDFoEeeP8_MeAypGlA">
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_whKEUDFpEeeP8_MeAypGlA" name="choiceToS6">
+          <language>bean</language>
+          <body>choiceToS6</body>
+        </effect>
+      </transition>
+      <subvertex xmi:type="uml:State" xmi:id="_e6aVkAOpEeaiNLSABY7wHw" name="S1"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_fyGykAOpEeaiNLSABY7wHw"/>
+      <subvertex xmi:type="uml:State" xmi:id="_hTUGoAOpEeaiNLSABY7wHw" name="S2"/>
+      <subvertex xmi:type="uml:State" xmi:id="_hwr_IAOpEeaiNLSABY7wHw" name="S3"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_in3ewAOpEeaiNLSABY7wHw" name="CHOICE1" kind="choice"/>
+      <subvertex xmi:type="uml:State" xmi:id="_1f3fgAOpEeaiNLSABY7wHw" name="S4"/>
+      <subvertex xmi:type="uml:State" xmi:id="__wwF4DFnEeeP8_MeAypGlA" name="S5"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_B9rQcDFoEeeP8_MeAypGlA" name="CHOICE2" kind="choice"/>
+      <subvertex xmi:type="uml:State" xmi:id="_FQg6MDFoEeeP8_MeAypGlA" name="S6"/>
+    </region>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Signal" xmi:id="_61ApIAOyEeaiNLSABY7wHw" name="E1"/>
+  <packagedElement xmi:type="uml:SignalEvent" xmi:id="_9sMRoAOyEeaiNLSABY7wHw" name="SignalEventE1" signal="_61ApIAOyEeaiNLSABY7wHw"/>
+</uml:Model>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-junction.di
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-junction.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"/>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-junction.notation
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-junction.notation
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/viewpoints/policy/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_OrqPAAOpEeaiNLSABY7wHw" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_OrqPAQOpEeaiNLSABY7wHw" type="2000">
+    <children xmi:type="notation:DecorationNode" xmi:id="_OrqPAgOpEeaiNLSABY7wHw" type="2001">
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPAwOpEeaiNLSABY7wHw" width="831" height="23"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_OrqPBAOpEeaiNLSABY7wHw" type="2002">
+      <children xmi:type="notation:Shape" xmi:id="_OrqPBQOpEeaiNLSABY7wHw" type="3000">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_OrqPBgOpEeaiNLSABY7wHw" source="RegionAnnotationKey">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_OrqPBwOpEeaiNLSABY7wHw" key="RegionZoneKey" value=""/>
+        </eAnnotations>
+        <children xmi:type="notation:DecorationNode" xmi:id="_OrqPCAOpEeaiNLSABY7wHw" type="3002">
+          <children xmi:type="notation:Shape" xmi:id="_e6i4cAOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_e6i4cgOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_kOQNwAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_e6jfgAOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_e6jfgQOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_e6jfggOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e6jfgwOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-junction.uml#_e6aVkAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_e6i4cQOpEeaiNLSABY7wHw" x="110" y="107" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_fyMSIAOpEeaiNLSABY7wHw" type="8000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_fyM5MAOpEeaiNLSABY7wHw" type="8001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_fyM5MQOpEeaiNLSABY7wHw" x="25" y="3"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_fyM5MgOpEeaiNLSABY7wHw" type="8002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_fyM5MwOpEeaiNLSABY7wHw" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="action-with-transition-junction.uml#_fyGykAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_fyMSIQOpEeaiNLSABY7wHw" x="30" y="107"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_hTbbYAOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_hTbbYgOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ln3FAAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hTbbYwOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_hTbbZAOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hTbbZQOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hTbbZgOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-junction.uml#_hTUGoAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hTbbYQOpEeaiNLSABY7wHw" x="490" y="27" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_hwzT4AOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_hwzT4gOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ln3sEAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hwzT4wOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_hwzT5AOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_hwzT5QOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwzT5gOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-junction.uml#_hwr_IAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_hwzT4QOpEeaiNLSABY7wHw" x="490" y="87" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_1gApcAOpEeaiNLSABY7wHw" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_1gBQgAOpEeaiNLSABY7wHw" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3uzcQAOpEeaiNLSABY7wHw" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_1gBQgQOpEeaiNLSABY7wHw" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_1gBQggOpEeaiNLSABY7wHw" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_1gBQgwOpEeaiNLSABY7wHw" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gBQhAOpEeaiNLSABY7wHw" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-junction.uml#_1f3fgAOpEeaiNLSABY7wHw"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_1gApcQOpEeaiNLSABY7wHw" x="110" y="227" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="__xK8oDFnEeeP8_MeAypGlA" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="__xLjsDFnEeeP8_MeAypGlA" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BCpLkDFoEeeP8_MeAypGlA" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="__xLjsTFnEeeP8_MeAypGlA" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="__xLjsjFnEeeP8_MeAypGlA" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="__xLjszFnEeeP8_MeAypGlA" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xLjtDFnEeeP8_MeAypGlA" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-junction.uml#__wwF4DFnEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="__xK8oTFnEeeP8_MeAypGlA" x="650" y="207" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_FQwKwDFoEeeP8_MeAypGlA" type="6000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_FQwKwjFoEeeP8_MeAypGlA" type="6001">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_GR_lUDFoEeeP8_MeAypGlA" width="83"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_FQwKwzFoEeeP8_MeAypGlA" type="19003">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_FQwKxDFoEeeP8_MeAypGlA" x="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_FQwx0DFoEeeP8_MeAypGlA" type="6002">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FQwx0TFoEeeP8_MeAypGlA" y="-1" width="83"/>
+            </children>
+            <element xmi:type="uml:State" href="action-with-transition-junction.uml#_FQg6MDFoEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FQwKwTFoEeeP8_MeAypGlA" x="650" y="307" width="83"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_BuDEwDGDEeeP8_MeAypGlA" type="12000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_BuDEwjGDEeeP8_MeAypGlA" type="12001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_BuDEwzGDEeeP8_MeAypGlA" x="-80" y="-20"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_BuDr0DGDEeeP8_MeAypGlA" type="12002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_BuDr0TGDEeeP8_MeAypGlA" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="action-with-transition-junction.uml#_Bt0bQDGDEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_BuDEwTGDEeeP8_MeAypGlA" x="270" y="107"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_DrwHkDGDEeeP8_MeAypGlA" type="12000">
+            <children xmi:type="notation:DecorationNode" xmi:id="_DrwuoDGDEeeP8_MeAypGlA" type="12001">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_DrwuoTGDEeeP8_MeAypGlA" x="-40" y="40"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_DrwuojGDEeeP8_MeAypGlA" type="12002">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_DrwuozGDEeeP8_MeAypGlA" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="action-with-transition-junction.uml#_Drg3ADGDEeeP8_MeAypGlA"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_DrwHkTGDEeeP8_MeAypGlA" x="450" y="187"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPCQOpEeaiNLSABY7wHw"/>
+        </children>
+        <element xmi:type="uml:Region" href="action-with-transition-junction.uml#_OrpA4AOpEeaiNLSABY7wHw"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPCgOpEeaiNLSABY7wHw" width="831" height="388"/>
+      </children>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPCwOpEeaiNLSABY7wHw" y="23" width="831" height="388"/>
+    </children>
+    <element xmi:type="uml:StateMachine" href="action-with-transition-junction.uml#_OrcMkAOpEeaiNLSABY7wHw"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_OrqPDAOpEeaiNLSABY7wHw" x="30" y="30" width="831" height="411"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_OrqPDQOpEeaiNLSABY7wHw" name="diagram_compatibility_version" stringValue="1.1.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_OrqPDgOpEeaiNLSABY7wHw"/>
+  <styles xmi:type="style:PapyrusViewStyle" xmi:id="_OrqPDwOpEeaiNLSABY7wHw">
+    <owner xmi:type="uml:Model" href="action-with-transition-junction.uml#_OqqwgAOpEeaiNLSABY7wHw"/>
+  </styles>
+  <element xmi:type="uml:StateMachine" href="action-with-transition-junction.uml#_OrcMkAOpEeaiNLSABY7wHw"/>
+  <edges xmi:type="notation:Connector" xmi:id="_7ZbT4AOpEeaiNLSABY7wHw" type="7000" source="_fyMSIAOpEeaiNLSABY7wHw" target="_e6i4cAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_7Zb68AOpEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_7Zb68QOpEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_7Zb68gOpEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_7Zb68wOpEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_7Zb69AOpEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_7Zb69QOpEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_7ZbT4QOpEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_7V6s4AOpEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7ZbT4gOpEeaiNLSABY7wHw" points="[8, -4, -123, 0]$[130, -10, -1, -6]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aHQYAOpEeaiNLSABY7wHw" id="(1.0,0.5)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7aH3cAOpEeaiNLSABY7wHw" id="(0.0,0.14893617021276595)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_X0QVwAOqEeaiNLSABY7wHw" type="7000" source="_e6i4cAOpEeaiNLSABY7wHw" target="_BuDEwDGDEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_X0Q80AOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_X0Q80QOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_X0Q80gOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_X0Q80wOqEeaiNLSABY7wHw" x="10" y="17"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_X0Q81AOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_X0Q81QOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_X0QVwQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_X0EvkAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_X0QVwgOqEeaiNLSABY7wHw" points="[5, 0, -89, -10]$[86, 10, -8, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X0wsEAOqEeaiNLSABY7wHw" id="(0.891566265060241,0.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_X0wsEQOqEeaiNLSABY7wHw" id="(0.65,1.0)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_ar9isAOqEeaiNLSABY7wHw" type="7000" source="_BuDEwDGDEeeP8_MeAypGlA" target="_hTbbYAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_ar-JwAOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_ar-JwQOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_ar-JwgOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_ar-JwwOqEeaiNLSABY7wHw" x="-10" y="-16"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_ar-JxAOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_ar-JxQOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_ar9isQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_arx8gAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ar9isgOqEeaiNLSABY7wHw" points="[-6, 3, -220, 58]$[-6, -55, -220, 0]$[214, -55, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ascq4AOqEeaiNLSABY7wHw" id="(0.65,0.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ascq4QOqEeaiNLSABY7wHw" id="(0.0,0.5319148936170213)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_bfppcAOqEeaiNLSABY7wHw" type="7000" source="_BuDEwDGDEeeP8_MeAypGlA" target="_hwzT4AOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_bfppcwOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_bfppdAOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_bfppdQOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_bfppdgOqEeaiNLSABY7wHw" x="10" y="-22"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_bfqQgAOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_bfqQgQOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_bfppcQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_bfbnAAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_bfppcgOqEeaiNLSABY7wHw" points="[20, 3, -90, 13]$[144, 37, 34, 47]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bgNqIAOqEeaiNLSABY7wHw" id="(1.0,0.5333333333333333)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_bgNqIQOqEeaiNLSABY7wHw" id="(0.0,0.574468085106383)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_cJG2IAOqEeaiNLSABY7wHw" type="7000" source="_BuDEwDGDEeeP8_MeAypGlA" target="_1gApcAOpEeaiNLSABY7wHw">
+    <children xmi:type="notation:DecorationNode" xmi:id="_cJG2IwOqEeaiNLSABY7wHw" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_cJHdMAOqEeaiNLSABY7wHw"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_cJHdMQOqEeaiNLSABY7wHw" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_cJHdMgOqEeaiNLSABY7wHw" x="2" y="-14"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_cJHdMwOqEeaiNLSABY7wHw" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_cJHdNAOqEeaiNLSABY7wHw" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_cJG2IQOqEeaiNLSABY7wHw"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_cIytEAOqEeaiNLSABY7wHw"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_cJG2IgOqEeaiNLSABY7wHw" points="[0, -4, 77, -139]$[0, 135, 77, 0]$[-77, 135, 0, 0]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cJvIQAOqEeaiNLSABY7wHw" id="(0.6,1.0)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_cJvvUAOqEeaiNLSABY7wHw" id="(1.0,0.7446808510638298)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_JwVUcDFoEeeP8_MeAypGlA" type="7000" source="_BuDEwDGDEeeP8_MeAypGlA" target="_DrwHkDGDEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_JwVUczFoEeeP8_MeAypGlA" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_JwVUdDFoEeeP8_MeAypGlA"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_JwVUdTFoEeeP8_MeAypGlA" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_JwVUdjFoEeeP8_MeAypGlA" x="60" y="-40"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_JwVUdzFoEeeP8_MeAypGlA" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_JwVUeDFoEeeP8_MeAypGlA" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_JwVUcTFoEeeP8_MeAypGlA"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_Jv-vIDFoEeeP8_MeAypGlA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_JwVUcjFoEeeP8_MeAypGlA" points="[11, 6, -171, -88]$[183, 92, 1, -2]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JxAC0DFoEeeP8_MeAypGlA" id="(0.75,0.6666666666666666)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_JxAC0TFoEeeP8_MeAypGlA" id="(0.4,0.0)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_K29lUDFoEeeP8_MeAypGlA" type="7000" source="_DrwHkDGDEeeP8_MeAypGlA" target="__xK8oDFnEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_K29lUzFoEeeP8_MeAypGlA" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_K29lVDFoEeeP8_MeAypGlA"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_K29lVTFoEeeP8_MeAypGlA" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_K29lVjFoEeeP8_MeAypGlA" x="5" y="-23"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_K29lVzFoEeeP8_MeAypGlA" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_K29lWDFoEeeP8_MeAypGlA" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_K29lUTFoEeeP8_MeAypGlA"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_K2u70DFoEeeP8_MeAypGlA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_K29lUjFoEeeP8_MeAypGlA" points="[2, 0, -181, -15]$[175, 14, -8, -1]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3kCQDFoEeeP8_MeAypGlA" id="(1.0,0.4)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_K3kCQTFoEeeP8_MeAypGlA" id="(0.0,0.44680851063829785)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_LqcQsDFoEeeP8_MeAypGlA" type="7000" source="_DrwHkDGDEeeP8_MeAypGlA" target="_FQwKwDFoEeeP8_MeAypGlA">
+    <children xmi:type="notation:DecorationNode" xmi:id="_LqcQszFoEeeP8_MeAypGlA" type="7001">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Lqc3wDFoEeeP8_MeAypGlA"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_Lqc3wTFoEeeP8_MeAypGlA" type="7002">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Lqc3wjFoEeeP8_MeAypGlA" x="39" y="-12"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_Lqc3wzFoEeeP8_MeAypGlA" type="7003">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_Lqc3xDFoEeeP8_MeAypGlA" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_LqcQsTFoEeeP8_MeAypGlA"/>
+    <element xmi:type="uml:Transition" href="action-with-transition-junction.uml#_LqOOQDFoEeeP8_MeAypGlA"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_LqcQsjFoEeeP8_MeAypGlA" points="[11, 6, -199, -102]$[194, 104, -16, -4]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LrD7wDFoEeeP8_MeAypGlA" id="(1.0,0.5333333333333333)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_LrD7wTFoEeeP8_MeAypGlA" id="(0.0,0.19148936170212766)"/>
+  </edges>
+</notation:Diagram>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-junction.uml
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/action-with-transition-junction.uml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_OqqwgAOpEeaiNLSABY7wHw" name="RootElement">
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_OrcMkAOpEeaiNLSABY7wHw" name="StateMachine">
+    <region xmi:type="uml:Region" xmi:id="_OrpA4AOpEeaiNLSABY7wHw" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_7V6s4AOpEeaiNLSABY7wHw" source="_fyGykAOpEeaiNLSABY7wHw" target="_e6aVkAOpEeaiNLSABY7wHw"/>
+      <transition xmi:type="uml:Transition" xmi:id="_X0EvkAOqEeaiNLSABY7wHw" source="_e6aVkAOpEeaiNLSABY7wHw" target="_Bt0bQDGDEeeP8_MeAypGlA">
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_AKBlwDCdEeeP8_MeAypGlA" name="s1ToChoice">
+          <language>bean</language>
+          <body>s1ToChoice</body>
+        </effect>
+        <trigger xmi:type="uml:Trigger" xmi:id="_CVbtoAOzEeaiNLSABY7wHw" event="_9sMRoAOyEeaiNLSABY7wHw"/>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_arx8gAOqEeaiNLSABY7wHw" guard="_yT_ckAOtEeaiNLSABY7wHw" source="_Bt0bQDGDEeeP8_MeAypGlA" target="_hTUGoAOpEeaiNLSABY7wHw">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_yT_ckAOtEeaiNLSABY7wHw">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_yT_ckQOtEeaiNLSABY7wHw">
+            <language>bean</language>
+            <body>s2Guard</body>
+          </specification>
+        </ownedRule>
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_IDAUMDCdEeeP8_MeAypGlA" name="choiceToS2">
+          <language>bean</language>
+          <body>choiceToS2</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_bfbnAAOqEeaiNLSABY7wHw" guard="_9yVIIAOtEeaiNLSABY7wHw" source="_Bt0bQDGDEeeP8_MeAypGlA" target="_hwr_IAOpEeaiNLSABY7wHw">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_9yVIIAOtEeaiNLSABY7wHw">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_9yVIIQOtEeaiNLSABY7wHw">
+            <language>bean</language>
+            <body>s3Guard</body>
+          </specification>
+        </ownedRule>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_cIytEAOqEeaiNLSABY7wHw" source="_Bt0bQDGDEeeP8_MeAypGlA" target="_1f3fgAOpEeaiNLSABY7wHw">
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_LR1AoDCdEeeP8_MeAypGlA" name="choiceToS4">
+          <language>bean</language>
+          <body>choiceToS4</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_Jv-vIDFoEeeP8_MeAypGlA" guard="_UnE0gDFoEeeP8_MeAypGlA" source="_Bt0bQDGDEeeP8_MeAypGlA" target="_Drg3ADGDEeeP8_MeAypGlA">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_UnE0gDFoEeeP8_MeAypGlA">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_UnE0gTFoEeeP8_MeAypGlA" name="choice2Guard">
+            <language>bean</language>
+            <body>choice2Guard</body>
+          </specification>
+        </ownedRule>
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_q79L0DFoEeeP8_MeAypGlA" name="choice1ToChoice2">
+          <language>bean</language>
+          <body>choice1ToChoice2</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_K2u70DFoEeeP8_MeAypGlA" guard="_aQIHsDFoEeeP8_MeAypGlA" source="_Drg3ADGDEeeP8_MeAypGlA" target="__wwF4DFnEeeP8_MeAypGlA">
+        <ownedRule xmi:type="uml:Constraint" xmi:id="_aQIHsDFoEeeP8_MeAypGlA">
+          <specification xmi:type="uml:OpaqueExpression" xmi:id="_aQIHsTFoEeeP8_MeAypGlA" name="s5Guard">
+            <language>bean</language>
+            <body>s5Guard</body>
+          </specification>
+        </ownedRule>
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_POtMMDFpEeeP8_MeAypGlA" name="choiceToS5">
+          <language>bean</language>
+          <body>choiceToS5</body>
+        </effect>
+      </transition>
+      <transition xmi:type="uml:Transition" xmi:id="_LqOOQDFoEeeP8_MeAypGlA" source="_Drg3ADGDEeeP8_MeAypGlA" target="_FQg6MDFoEeeP8_MeAypGlA">
+        <effect xmi:type="uml:FunctionBehavior" xmi:id="_whKEUDFpEeeP8_MeAypGlA" name="choiceToS6">
+          <language>bean</language>
+          <body>choiceToS6</body>
+        </effect>
+      </transition>
+      <subvertex xmi:type="uml:State" xmi:id="_e6aVkAOpEeaiNLSABY7wHw" name="S1"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_fyGykAOpEeaiNLSABY7wHw"/>
+      <subvertex xmi:type="uml:State" xmi:id="_hTUGoAOpEeaiNLSABY7wHw" name="S2"/>
+      <subvertex xmi:type="uml:State" xmi:id="_hwr_IAOpEeaiNLSABY7wHw" name="S3"/>
+      <subvertex xmi:type="uml:State" xmi:id="_1f3fgAOpEeaiNLSABY7wHw" name="S4"/>
+      <subvertex xmi:type="uml:State" xmi:id="__wwF4DFnEeeP8_MeAypGlA" name="S5"/>
+      <subvertex xmi:type="uml:State" xmi:id="_FQg6MDFoEeeP8_MeAypGlA" name="S6"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_Bt0bQDGDEeeP8_MeAypGlA" name="JUNCTION1" kind="junction"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_Drg3ADGDEeeP8_MeAypGlA" name="JUNCTION2" kind="junction"/>
+    </region>
+  </packagedElement>
+  <packagedElement xmi:type="uml:Signal" xmi:id="_61ApIAOyEeaiNLSABY7wHw" name="E1"/>
+  <packagedElement xmi:type="uml:SignalEvent" xmi:id="_9sMRoAOyEeaiNLSABY7wHw" name="SignalEventE1" signal="_61ApIAOyEeaiNLSABY7wHw"/>
+</uml:Model>


### PR DESCRIPTION
- Adding support for javaconfig/uml to define
  actions for transitions leading out from a
  choice or junction states.
- Support for action for incoming transition is
  already implemented as it is defined as normal
  transition.
- Fixes #108