### PR TITLE
Add support for multiple end states with javaconfig

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class DefaultStateConfigurer<S, E>
 	private final Map<S, StateData<S, E>> incomplete = new HashMap<S, StateData<S, E>>();
 	private S initialState;
 	private Action<S, E> initialAction;
-	private S end;
+	private final Collection<S> ends = new ArrayList<>();
 	private S history;
 	private History historyType;
 	private final Collection<S> choices = new ArrayList<S>();
@@ -75,7 +75,7 @@ public class DefaultStateConfigurer<S, E>
 				s.setInitial(true);
 				s.setInitialAction(initialAction);
 			}
-			if (s.getState() == end) {
+			if (ends.contains(s.getState())) {
 				s.setEnd(true);
 			}
 			if (choices.contains(s.getState())) {
@@ -125,7 +125,7 @@ public class DefaultStateConfigurer<S, E>
 
 	@Override
 	public StateConfigurer<S, E> end(S end) {
-		this.end = end;
+		this.ends.add(end);
 		state(end);
 		return this;
 	}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,8 @@ public interface StateConfigurer<S, E> extends
 	StateConfigurer<S, E> states(Set<S> states);
 
 	/**
-	 * Specify a state {@code S} to be end state.
+	 * Specify a state {@code S} to be end state. This method
+	 * can be called for each state to be marked as end state.
 	 *
 	 * @param end the end state
 	 * @return configurer for chaining

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/EndStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/EndStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,6 +131,38 @@ public class EndStateTests extends AbstractStateMachineTests {
 	public void testMultipleTransitionsToSameEndStateFromChoices() {
 		context.register(Config6.class);
 		context.refresh();
+	}
+
+	@Test
+	public void testEndStateCompletesMultipleEndStates1() {
+		context.register(Config7.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		@SuppressWarnings("unchecked")
+		ObjectStateMachine<TestStates,TestEvents> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, ObjectStateMachine.class);
+		machine.start();
+		assertThat(machine, notNullValue());
+		assertThat(machine.isComplete(), is(false));
+		machine.sendEvent(TestEvents.E1);
+		assertThat(machine.isComplete(), is(true));
+		assertThat(machine.getState().getIds(), contains(TestStates.S1));
+	}
+
+	@Test
+	public void testEndStateCompletesMultipleEndStates2() {
+		context.register(Config7.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		@SuppressWarnings("unchecked")
+		ObjectStateMachine<TestStates,TestEvents> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, ObjectStateMachine.class);
+		machine.start();
+		assertThat(machine, notNullValue());
+		assertThat(machine.isComplete(), is(false));
+		machine.sendEvent(TestEvents.E2);
+		assertThat(machine.isComplete(), is(true));
+		assertThat(machine.getState().getIds(), contains(TestStates.S2));
 	}
 
 	@Configuration
@@ -434,6 +466,34 @@ public class EndStateTests extends AbstractStateMachineTests {
 				.withChoice()
 					.source("JOIN2")
 					.last("SF");
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config7 extends EnumStateMachineConfigurerAdapter<TestStates, TestEvents> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<TestStates, TestEvents> states) throws Exception {
+			states
+				.withStates()
+					.initial(TestStates.SI)
+					.end(TestStates.S1)
+					.end(TestStates.S2);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<TestStates, TestEvents> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(TestStates.SI)
+					.target(TestStates.S1)
+					.event(TestEvents.E1)
+					.and()
+				.withExternal()
+					.source(TestStates.SI)
+					.target(TestStates.S2)
+					.event(TestEvents.E2);
 		}
 	}
 }


### PR DESCRIPTION
- Add missing support for defining more than one
  end states and as it's just missing from javaconfig.
- Fixes #368