### PR TITLE
Fix terminal state for persist

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -824,12 +824,11 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 			setCurrentState(toState, message, transition, true, stateMachine, null, targets);
 		}
 
-		callPostStateChangeInterceptors(toState, message, transition, stateMachine);
-
 		stateMachineExecutor.execute();
 		if (isComplete()) {
 			stop();
 		}
+		callPostStateChangeInterceptors(toState, message, transition, stateMachine);
 	}
 
 	private State<S,E> followLinkedPseudoStates(State<S,E> state, StateContext<S, E> stateContext) {


### PR DESCRIPTION
- Now calling post state interceptors at end
  of state change which gives machine a change
  to stop if state is terminal.
- Fixes #379