### PR TITLE
Clean machine id when restored with null context

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -591,9 +591,10 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 	public void resetStateMachine(StateMachineContext<S, E> stateMachineContext) {
 		// TODO: this function needs a serious rewrite
 		if (stateMachineContext == null) {
-			log.info("Got null context, resetting to initial state and clearing extended state");
+			log.info("Got null context, resetting to initial state, clearing extended state and machine id");
 			currentState = initialState;
 			extendedState.getVariables().clear();
+			setId(null);
 			return;
 		}
 		if (log.isDebugEnabled()) {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests3.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests3.java
@@ -113,6 +113,25 @@ public class StateMachinePersistTests3 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getId(), is("newid"));
 	}
 
+	@Test
+	public void testRestoreClearWithNullContext() throws Exception {
+		context.register(Config1.class);
+		context.refresh();
+		InMemoryStateMachinePersist1 stateMachinePersist = new InMemoryStateMachinePersist1();
+		StateMachinePersister<String, String, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
+		@SuppressWarnings("unchecked")
+		StateMachineFactory<String, String> stateMachineFactory = context.getBean(StateMachineFactory.class);
+
+		StateMachine<String,String> stateMachine = stateMachineFactory.getStateMachine("testid2");
+		assertThat(stateMachine, notNullValue());
+		assertThat(stateMachine.getId(), is("testid2"));
+
+		persister.persist(stateMachine, "xxx");
+
+		stateMachine = persister.restore(stateMachine, "notfound");
+		assertThat(stateMachine.getId(), nullValue());
+	}
+
 	@Configuration
 	@EnableStateMachineFactory
 	public static class Config1 extends StateMachineConfigurerAdapter<String, String> {


### PR DESCRIPTION
- Resetting a machine with null context currently
  just resets to initial state and clear extended
  state variables. Enhance also to clear machine id
  which as a user level variable may cause some other
  trouble. There are no internal functionality for this
  id as it's meant for user consumption.
- Fixes #390