### PR TITLE
Clear machine id with null context restore

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/AbstractState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/AbstractState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,17 +198,13 @@ public abstract class AbstractState<S, E> extends LifecycleObjectSupport impleme
 	public void exit(StateContext<S, E> context) {
 		cancelStateActions();
 		stateListener.onExit(context);
-		for (Trigger<S, E> trigger : triggers) {
-			trigger.disarm();
-		}
+		disarmTriggers();
 	}
 
 	@Override
 	public void entry(StateContext<S, E> context) {
 		stateListener.onEntry(context);
-		for (Trigger<S, E> trigger : triggers) {
-			trigger.arm();
-		}
+		armTriggers();
 		scheduleStateActions(context);
 	}
 
@@ -292,6 +288,16 @@ public abstract class AbstractState<S, E> extends LifecycleObjectSupport impleme
 		}
 	}
 
+	@Override
+	protected void doStart() {
+		armTriggers();
+	}
+
+	@Override
+	protected void doStop() {
+		disarmTriggers();
+	}
+
 	/**
 	 * Gets the submachine.
 	 *
@@ -330,6 +336,24 @@ public abstract class AbstractState<S, E> extends LifecycleObjectSupport impleme
 	 */
 	public List<Trigger<S, E>> getTriggers() {
 		return triggers;
+	}
+
+	/**
+	 * Arm triggers.
+	 */
+	protected void armTriggers() {
+		for (Trigger<S, E> trigger : triggers) {
+			trigger.arm();
+		}
+	}
+
+	/**
+	 * Disarm triggers.
+	 */
+	protected void disarmTriggers() {
+		for (Trigger<S, E> trigger : triggers) {
+			trigger.disarm();
+		}
 	}
 
 	/**

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.context.Lifecycle;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
@@ -718,6 +719,9 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		}
 		if (stateSet && stateMachineContext.getExtendedState() != null) {
 			this.extendedState = stateMachineContext.getExtendedState();
+		}
+		if (currentState instanceof Lifecycle) {
+			((Lifecycle)currentState).start();
 		}
 	}
 


### PR DESCRIPTION
- As passing in null context don't have any
  meaning other than doing reset with pre-defined
  behaviour which currently just resets back to
  initial state and clears extended state variables.
  Now Also clearing machine id back to null which is
  anyway a default value.
- Fixes #381