### PR TITLE
Fix logging message when transition action throws exception

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -287,7 +287,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 				} catch (Exception e) {
 					// aborting, executor should stop possible loop checking possible transitions
 					// causing infinite execution
-					log.warn("Aborting as transition " + t + " caused error " + e);
+					log.warn("Aborting as transition " + t, e);
 					throw new StateMachineException("Aborting as transition " + t + " caused error ", e);
 				}
 				notifyTransition(buildStateContext(Stage.TRANSITION, message, t, getRelayStateMachine()));

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
@@ -240,7 +240,7 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 			try {
 				transit = t.transit(stateContext);
 			} catch (Exception e) {
-				log.warn("Aborting as transition " + t + " caused error " + e);
+				log.warn("Aborting as transition " + t, e);
 			}
 			if (transit) {
 				// if executor transit is raising exception, stop here


### PR DESCRIPTION
Hello,

Error during execution of `Action` during (internal or external) transition was not fully logged.

```java
Builder<String, String> builder = StateMachineBuilder.builder();
builder
    .configureConfiguration()
        .withConfiguration()
            .beanFactory(beanFactory)
            .autoStartup(true);
builder
    .configureStates()
        .withStates()
            .initial("a")
            .states(new HashSet<>(asList("a", "b")));
builder
    .configureTransitions()
        .withInternal()
            .source("a")
            .event("int")
            .action(c -> { throw new RuntimeException("oups"); })
            .and()
        .withExternal()
            .source("a")
            .event("ext")
            .action(c -> { throw new RuntimeException("oups"); })
            .target("b");
StateMachine<String, String> stateMachine = builder.build();

stateMachine.sendEvent("int");
stateMachine.sendEvent("ext");
```

Original logging:
```
2017-09-17 19:18:24.331  WARN 11944 --- [           main] o.s.s.support.AbstractStateMachine       : Aborting as transition org.springframework.statemachine.transition.DefaultInternalTransition@49f5c307 caused error java.lang.RuntimeException: oups
```

After modification:
```
2017-09-17 22:40:27.867  WARN 1768 --- [           main] o.s.s.support.AbstractStateMachine       : Aborting as transition org.springframework.statemachine.transition.DefaultExternalTransition@66971f6b

java.lang.RuntimeException: oups
	at fr.pinguet62.statemachine.logging.LoggingRunner.lambda$1(LoggingRunner.java:50) [classes/:na]
	at org.springframework.statemachine.transition.AbstractTransition.executeTransitionActions(AbstractTransition.java:165) ~[spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.AbstractStateMachine$2.transit(AbstractStateMachine.java:286) ~[spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.DefaultStateMachineExecutor.handleTriggerTrans(DefaultStateMachineExecutor.java:248) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.DefaultStateMachineExecutor.processTriggerQueue(DefaultStateMachineExecutor.java:395) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.DefaultStateMachineExecutor.access$100(DefaultStateMachineExecutor.java:61) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.DefaultStateMachineExecutor$1.run(DefaultStateMachineExecutor.java:281) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.core.task.SyncTaskExecutor.execute(SyncTaskExecutor.java:50) [spring-core-4.3.4.RELEASE.jar:4.3.4.RELEASE]
	at org.springframework.statemachine.support.DefaultStateMachineExecutor.scheduleEventQueueProcessing(DefaultStateMachineExecutor.java:300) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.DefaultStateMachineExecutor.execute(DefaultStateMachineExecutor.java:144) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.AbstractStateMachine.sendEventInternal(AbstractStateMachine.java:559) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.AbstractStateMachine.sendEvent(AbstractStateMachine.java:211) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
	at org.springframework.statemachine.support.AbstractStateMachine.sendEvent(AbstractStateMachine.java:223) [spring-statemachine-core-1.2.7.BUILD-SNAPSHOT.jar:1.2.7.BUILD-SNAPSHOT]
...
```