### PR TITLE
Change persistence model structure

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
@@ -75,7 +75,7 @@ public class StateMachineConfigurationBuilder<S, E>
 	private SecurityRule transitionSecurityRule;
 	private StateMachineMonitor<S, E> stateMachineMonitor;
 	private final List<StateMachineInterceptor<S, E>> interceptors = new ArrayList<StateMachineInterceptor<S, E>>();
-	private StateMachineRuntimePersister<S, E> persister;
+	private StateMachineRuntimePersister<S, E, ?> persister;
 
 	/**
 	 * Instantiates a new state machine configuration builder.
@@ -289,7 +289,7 @@ public class StateMachineConfigurationBuilder<S, E>
 	 *
 	 * @param persister the state machine runtime persister
 	 */
-	public void setStateMachineRuntimePersister(StateMachineRuntimePersister<S, E> persister) {
+	public void setStateMachineRuntimePersister(StateMachineRuntimePersister<S, E, ?> persister) {
 		this.persister = persister;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultPersistenceConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultPersistenceConfigurer.java
@@ -33,7 +33,7 @@ public class DefaultPersistenceConfigurer<S, E> extends
 		AnnotationConfigurerAdapter<ConfigurationData<S, E>, StateMachineConfigurationConfigurer<S, E>, StateMachineConfigurationBuilder<S, E>>
 		implements PersistenceConfigurer<S, E> {
 
-	private StateMachineRuntimePersister<S, E> persister;
+	private StateMachineRuntimePersister<S, E, ?> persister;
 
 	@Override
 	public void configure(StateMachineConfigurationBuilder<S, E> builder) throws Exception {
@@ -41,7 +41,7 @@ public class DefaultPersistenceConfigurer<S, E> extends
 	}
 
 	@Override
-	public PersistenceConfigurer<S, E> runtimePersister(StateMachineRuntimePersister<S, E> persister) {
+	public PersistenceConfigurer<S, E> runtimePersister(StateMachineRuntimePersister<S, E, ?> persister) {
 		this.persister = persister;
 		return this;
 	}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/PersistenceConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/PersistenceConfigurer.java
@@ -36,5 +36,5 @@ public interface PersistenceConfigurer<S, E> extends
 	 * @param persister the state machine runtime persister
 	 * @return configurer for chaining
 	 */
-	PersistenceConfigurer<S, E> runtimePersister(StateMachineRuntimePersister<S, E> persister);
+	PersistenceConfigurer<S, E> runtimePersister(StateMachineRuntimePersister<S, E, ?> persister);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/AbstractPersistingStateMachineInterceptor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/AbstractPersistingStateMachineInterceptor.java
@@ -49,9 +49,10 @@ import org.springframework.statemachine.transition.TransitionKind;
  *
  * @param <S> the type of state
  * @param <E> the type of event
+ * @param <T> the type of persister context object
  */
-public abstract class AbstractPersistingStateMachineInterceptor<S, E> extends StateMachineInterceptorAdapter<S, E>
-		implements StateMachinePersist<S, E, Object> {
+public abstract class AbstractPersistingStateMachineInterceptor<S, E, T> extends StateMachineInterceptorAdapter<S, E>
+		implements StateMachinePersist<S, E, T> {
 
 	@Override
 	public void preStateChange(State<S, E> state, Message<E> message, Transition<S, E> transition, StateMachine<S, E> stateMachine) {
@@ -85,7 +86,7 @@ public abstract class AbstractPersistingStateMachineInterceptor<S, E> extends St
 	 * @param context the state machine context
 	 * @param contextObj the context object
 	 */
-	public abstract void write(StateMachineContext<S, E> context, Object contextObj) throws Exception;
+	public abstract void write(StateMachineContext<S, E> context, T contextObj) throws Exception;
 
 	/**
 	 * Read {@link StateMachineContext} from persistent store.
@@ -93,7 +94,7 @@ public abstract class AbstractPersistingStateMachineInterceptor<S, E> extends St
 	 * @param contextObj the context object
 	 * @return the state machine context
 	 */
-	public abstract StateMachineContext<S, E> read(Object contextObj) throws Exception;
+	public abstract StateMachineContext<S, E> read(T contextObj) throws Exception;
 
 	/**
 	 * Builds the state machine context.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/StateMachineRuntimePersister.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/StateMachineRuntimePersister.java
@@ -16,6 +16,7 @@
 package org.springframework.statemachine.persist;
 
 import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachinePersist;
 import org.springframework.statemachine.support.StateMachineInterceptor;
 
 /**
@@ -25,8 +26,9 @@ import org.springframework.statemachine.support.StateMachineInterceptor;
  *
  * @param <S> the type of state
  * @param <E> the type of event
+ * @param <T> the type of persister context object
  */
-public interface StateMachineRuntimePersister<S, E> {
+public interface StateMachineRuntimePersister<S, E, T> extends StateMachinePersist<S, E, T> {
 
 	/**
 	 * Gets a {@link StateMachineInterceptor} handling machine persistence.

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaPersistingStateMachineInterceptor.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaPersistingStateMachineInterceptor.java
@@ -16,7 +16,6 @@
 package org.springframework.statemachine.data.jpa;
 
 import org.springframework.statemachine.StateMachineContext;
-import org.springframework.statemachine.StateMachinePersist;
 import org.springframework.statemachine.persist.AbstractPersistingStateMachineInterceptor;
 import org.springframework.statemachine.persist.StateMachineRuntimePersister;
 import org.springframework.statemachine.support.StateMachineInterceptor;
@@ -29,9 +28,10 @@ import org.springframework.util.Assert;
  *
  * @param <S> the type of state
  * @param <E> the type of event
+ * @param <T> the type of persister context object
  */
-public class JpaPersistingStateMachineInterceptor<S, E> extends AbstractPersistingStateMachineInterceptor<S, E>
-		implements StateMachinePersist<S, E, Object>, StateMachineRuntimePersister<S, E> {
+public class JpaPersistingStateMachineInterceptor<S, E, T> extends AbstractPersistingStateMachineInterceptor<S, E, T>
+		implements StateMachineRuntimePersister<S, E, T> {
 
 	private final JpaRepositoryStateMachinePersist<S, E> persist;
 
@@ -61,7 +61,7 @@ public class JpaPersistingStateMachineInterceptor<S, E> extends AbstractPersisti
 	}
 
 	@Override
-	public void write(StateMachineContext<S, E> context, Object contextObj) throws Exception {
+	public void write(StateMachineContext<S, E> context, T contextObj) throws Exception {
 		persist.write(context, contextObj);
 	}
 

--- a/spring-statemachine-data/jpa/src/test/java/org/springframework/statemachine/data/jpa/JpaRepositoryTests.java
+++ b/spring-statemachine-data/jpa/src/test/java/org/springframework/statemachine/data/jpa/JpaRepositoryTests.java
@@ -363,7 +363,7 @@ public class JpaRepositoryTests extends AbstractRepositoryTests {
 		}
 
 		@Bean
-		public StateMachineRuntimePersister<String, String> stateMachineRuntimePersister() {
+		public StateMachineRuntimePersister<String, String, String> stateMachineRuntimePersister() {
 			return new JpaPersistingStateMachineInterceptor<>(jpaStateMachineRepository);
 		}
 	}
@@ -408,7 +408,7 @@ public class JpaRepositoryTests extends AbstractRepositoryTests {
 		}
 
 		@Bean
-		public StateMachineRuntimePersister<PersistTestStates, PersistTestEvents> stateMachineRuntimePersister() {
+		public StateMachineRuntimePersister<PersistTestStates, PersistTestEvents, String> stateMachineRuntimePersister() {
 			return new JpaPersistingStateMachineInterceptor<>(jpaStateMachineRepository);
 		}
 	}

--- a/spring-statemachine-samples/datajpapersist/src/main/java/demo/datajpapersist/StateMachineConfig.java
+++ b/spring-statemachine-samples/datajpapersist/src/main/java/demo/datajpapersist/StateMachineConfig.java
@@ -20,7 +20,6 @@ import java.util.EnumSet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.statemachine.StateMachinePersist;
 import org.springframework.statemachine.config.EnableStateMachineFactory;
 import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.StateMachineFactory;
@@ -49,7 +48,7 @@ public class StateMachineConfig {
 				throws Exception {
 			config
 				.withPersistence()
-					.runtimePersister(stateMachineruntimePersister());
+					.runtimePersister(stateMachineRuntimePersister());
 		}
 
 		@Override
@@ -91,7 +90,7 @@ public class StateMachineConfig {
 		}
 
 		@Bean
-		public StateMachineRuntimePersister<States, Events> stateMachineruntimePersister() {
+		public StateMachineRuntimePersister<States, Events, String> stateMachineRuntimePersister() {
 			return new JpaPersistingStateMachineInterceptor<>(jpaStateMachineRepository);
 		}
 	}
@@ -102,8 +101,8 @@ public class StateMachineConfig {
 
 		@Bean
 		public StateMachineService<States, Events> stateMachineService(StateMachineFactory<States, Events> stateMachineFactory,
-				StateMachinePersist<States, Events, String> stateMachinePersist) {
-			return new DefaultStateMachineService<>(stateMachineFactory, stateMachinePersist);
+				StateMachineRuntimePersister<States, Events, String> stateMachineRuntimePersister) {
+			return new DefaultStateMachineService<States, Events>(stateMachineFactory, stateMachineRuntimePersister);
 		}
 	}
 


### PR DESCRIPTION
- Fix wrong acquire logic in DefaultStatemachineService.
- Overhaul StateMachineRuntimePersister
- Change StateMachineRuntimePersister to extend
  StateMachinePersist which should work better on
  a bean level. Also add generic type T to it and
  config where needed.
- Relates to #432
- Relates to #427