### PR TITLE
Fix threading issues

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -64,6 +64,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Base implementation of a {@link StateMachine} loosely modelled from UML state
@@ -175,8 +176,9 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 	public State<S,E> getState() {
 		// if we're complete assume we're stopped
 		// and state was stashed into lastState
-		if (lastState != null && isComplete()) {
-			return lastState;
+		State<S, E> s = lastState;
+		if (s != null && isComplete()) {
+			return s;
 		} else {
 			return currentState;
 		}
@@ -279,6 +281,19 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 
 			@Override
 			public void transit(Transition<S, E> t, StateContext<S, E> ctx, Message<E> message) {
+				if (currentState != null && currentState.isSubmachineState()) {
+					// this is a naive attempt to check from submachine's executor if it is
+					// currently executing. allows submachine to complete its execution logic
+					// before we, in parent go forward. as executor locks, we simple try to lock it
+					// and release it immediately.
+					StateMachine<S, E> submachine = ((AbstractState<S, E>)currentState).getSubmachine();
+					Lock lock = ((AbstractStateMachine<S, E>)submachine).getStateMachineExecutor().getLock();
+					try {
+						lock.lock();
+					} finally {
+						lock.unlock();
+					}
+				}
 				long now = System.currentTimeMillis();
 				// TODO: fix above stateContext as it's not used
 				notifyTransitionStart(buildStateContext(Stage.TRANSITION_START, message, t, getRelayStateMachine()));
@@ -325,6 +340,10 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 				}
 			});
 		}
+	}
+
+	protected StateMachineExecutor<S, E> getStateMachineExecutor() {
+		return stateMachineExecutor;
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/StateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/StateMachineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 package org.springframework.statemachine.support;
+
+import java.util.concurrent.locks.Lock;
 
 import org.springframework.messaging.Message;
 import org.springframework.statemachine.StateContext;
@@ -101,6 +103,13 @@ public interface StateMachineExecutor<S, E> {
 	 * @param interceptor the interceptor
 	 */
 	void addStateMachineInterceptor(StateMachineInterceptor<S, E> interceptor);
+
+	/**
+	 * Gets the execution lock.
+	 *
+	 * @return the execution lock
+	 */
+	Lock getLock();
 
 	/**
 	 * Callback interface when executor wants to handle transit.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventHeaderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventHeaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
@@ -179,6 +181,199 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, nullValue());
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testHeaderPassedToInitialInSubs1Threading() throws InterruptedException {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		HeaderTestAction headerTestAction1I = context.getBean("headerTestAction1I", HeaderTestAction.class);
+		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
+		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
+		HeaderTestAction headerTestAction111 = context.getBean("headerTestAction111", HeaderTestAction.class);
+		HeaderTestAction headerTestAction112 = context.getBean("headerTestAction112", HeaderTestAction.class);
+		TestListener listener = new TestListener();
+		listener.reset(1);
+		machine.addStateListener(listener);
+		machine.start();
+
+		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		listener.reset(3);
+		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(3));
+
+		assertThat(headerTestAction1I.testHeader, is("testValue"));
+		assertThat(headerTestAction1.testHeader, is("testValue"));
+		assertThat(headerTestAction11.testHeader, is("testValue"));
+		assertThat(headerTestAction111.testHeader, is("testValue"));
+		assertThat(headerTestAction112.testHeader, nullValue());
+
+		headerTestAction1.testHeader = null;
+		headerTestAction11.testHeader = null;
+		headerTestAction111.testHeader = null;
+
+		listener.reset(1);
+		machine.sendEvent(MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		assertThat(headerTestAction1.testHeader, nullValue());
+		assertThat(headerTestAction11.testHeader, nullValue());
+		assertThat(headerTestAction111.testHeader, nullValue());
+		assertThat(headerTestAction112.testHeader, is("testValue"));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testHeaderPassedToInitialInSubs2Threading() throws InterruptedException {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
+		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
+		HeaderTestAction headerTestAction111 = context.getBean("headerTestAction111", HeaderTestAction.class);
+		HeaderTestAction headerTestAction112 = context.getBean("headerTestAction112", HeaderTestAction.class);
+		TestListener listener = new TestListener();
+		listener.reset(1);
+		machine.addStateListener(listener);
+		machine.start();
+
+		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		listener.reset(3);
+		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(3));
+
+		assertThat(headerTestAction1.testHeader, is("testValue"));
+		assertThat(headerTestAction11.testHeader, is("testValue"));
+		assertThat(headerTestAction111.testHeader, is("testValue"));
+		assertThat(headerTestAction112.testHeader, nullValue());
+
+		headerTestAction1.testHeader = null;
+		headerTestAction11.testHeader = null;
+		headerTestAction111.testHeader = null;
+
+		listener.reset(1);
+		machine.sendEvent(MessageBuilder.withPayload("E2").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		assertThat(headerTestAction1.testHeader, nullValue());
+		assertThat(headerTestAction11.testHeader, nullValue());
+		assertThat(headerTestAction111.testHeader, nullValue());
+		assertThat(headerTestAction112.testHeader, nullValue());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testHeaderPassedToInitialInSubs3Threading() throws InterruptedException {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		HeaderTestAction headerTestAction1I = context.getBean("headerTestAction1I", HeaderTestAction.class);
+		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
+		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
+		HeaderTestAction headerTestAction111 = context.getBean("headerTestAction111", HeaderTestAction.class);
+		HeaderTestAction headerTestAction112 = context.getBean("headerTestAction112", HeaderTestAction.class);
+		TestListener listener = new TestListener();
+		listener.reset(1);
+		machine.addStateListener(listener);
+		machine.start();
+
+		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		listener.reset(3);
+		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(3));
+
+		listener.reset(1);
+		machine.sendEvent(MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		headerTestAction1I.testHeader = null;
+		headerTestAction1.testHeader = null;
+		headerTestAction11.testHeader = null;
+		headerTestAction111.testHeader = null;
+		headerTestAction112.testHeader = null;
+		listener.reset(1);
+		machine.sendEvent(MessageBuilder.withPayload("E3").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		assertThat(headerTestAction1I.testHeader, nullValue());
+		assertThat(headerTestAction1.testHeader, nullValue());
+		assertThat(headerTestAction11.testHeader, nullValue());
+		assertThat(headerTestAction111.testHeader, is("testValue"));
+		assertThat(headerTestAction112.testHeader, nullValue());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testHeaderPassedWithAnonymousTransition() throws InterruptedException {
+		context.register(Config3.class);
+		context.refresh();
+		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
+		HeaderTestAction headerTestAction2 = context.getBean("headerTestAction2", HeaderTestAction.class);
+		HeaderTestAction headerTestAction3 = context.getBean("headerTestAction3", HeaderTestAction.class);
+		TestListener listener = new TestListener();
+		listener.reset(1);
+		machine.addStateListener(listener);
+		machine.start();
+
+		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		listener.reset(3);
+		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(3));
+
+		assertThat(headerTestAction1.testHeader, is("testValue"));
+		assertThat(headerTestAction2.testHeader, is("testValue"));
+		assertThat(headerTestAction3.testHeader, is("testValue"));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testHeaderPassedWithAnonymousTransitionThreading() throws InterruptedException {
+		context.register(Config4.class);
+		context.refresh();
+		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
+		HeaderTestAction headerTestAction2 = context.getBean("headerTestAction2", HeaderTestAction.class);
+		HeaderTestAction headerTestAction3 = context.getBean("headerTestAction3", HeaderTestAction.class);
+		TestListener listener = new TestListener();
+		listener.reset(1);
+		machine.addStateListener(listener);
+		machine.start();
+
+		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(1));
+
+		listener.reset(3);
+		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(listener.stateChangedCount, is(3));
+
+		assertThat(headerTestAction1.testHeader, is("testValue"));
+		assertThat(headerTestAction2.testHeader, is("testValue"));
+		assertThat(headerTestAction3.testHeader, is("testValue"));
+	}
+
 	@Configuration
 	@EnableStateMachine
 	static class Config1 extends StateMachineConfigurerAdapter<String, String> {
@@ -245,6 +440,183 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		@Bean
 		public HeaderTestAction headerTestAction112() {
 			return new HeaderTestAction();
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config2 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("SI")
+					.state("S1", headerTestAction1(), null)
+					.and()
+					.withStates()
+						.parent("S1")
+						.initial("S11", headerTestAction1I())
+						.state("S11", headerTestAction11(), null)
+						.state("S12")
+						.and()
+						.withStates()
+							.parent("S11")
+							.initial("S111")
+							.state("S111", headerTestAction111(), null)
+							.state("S122", headerTestAction112(), null);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("SI")
+					.target("S1")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S111")
+					.target("S122")
+					.event("E2")
+					.and()
+				.withExternal()
+					.source("S122")
+					.target("S111")
+					.event("E3");
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction1I() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction1() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction11() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction111() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction112() {
+			return new HeaderTestAction();
+		}
+
+		@Bean(name = StateMachineSystemConstants.TASK_EXECUTOR_BEAN_NAME)
+		public TaskExecutor taskExecutor() {
+			ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+			executor.setCorePoolSize(1);
+			return executor;
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config3 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("SI")
+					.state("S1", headerTestAction1(), null)
+					.state("S2", headerTestAction2(), null)
+					.state("S3", headerTestAction3(), null);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("SI")
+					.target("S1")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction1() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction2() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction3() {
+			return new HeaderTestAction();
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config4 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("SI")
+					.state("S1", headerTestAction1(), null)
+					.state("S2", headerTestAction2(), null)
+					.state("S3", headerTestAction3(), null);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("SI")
+					.target("S1")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction1() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction2() {
+			return new HeaderTestAction();
+		}
+
+		@Bean
+		public HeaderTestAction headerTestAction3() {
+			return new HeaderTestAction();
+		}
+
+		@Bean(name = StateMachineSystemConstants.TASK_EXECUTOR_BEAN_NAME)
+		public TaskExecutor taskExecutor() {
+			ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+			executor.setCorePoolSize(3);
+			return executor;
 		}
 	}
 


### PR DESCRIPTION
- In AbstractStateMachine and DefaultStateMachineExecutor
  do a little more synchronisation so that submachine is allowed
  to do its run-to-completion before parent machine can do its
  own transitions. This should fix use cases, when submachine
  starts, does its transitions and actions, parent wont try to
  do its own triggerless transtions.
- Adding some new tests and fixing one other sync issue with end state.
- Relates to #442