### PR TITLE
Add start/stop feature to DefaultStateMachineService

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/service/StateMachineService.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/service/StateMachineService.java
@@ -29,17 +29,38 @@ import org.springframework.statemachine.StateMachine;
 public interface StateMachineService<S, E> {
 
 	/**
-	 * Acquires the state machine.
+	 * Acquires the state machine. Machine from this method
+	 * is returned started.
 	 *
 	 * @param machineId the machine id
 	 * @return the state machine
+	 * @see #acquireStateMachine(String, boolean)
 	 */
 	StateMachine<S, E> acquireStateMachine(String machineId);
 
 	/**
-	 * Release the state machine.
+	 * Acquires the state machine.
 	 *
 	 * @param machineId the machine id
+	 * @param start indicating if machine should be returned started
+	 * @return the state machine
+	 */
+	StateMachine<S, E> acquireStateMachine(String machineId, boolean start);
+
+	/**
+	 * Release the state machine. Machine with this method
+	 * is stopped.
+	 *
+	 * @param machineId the machine id
+	 * @see #releaseStateMachine(String, boolean)
 	 */
 	void releaseStateMachine(String machineId);
+
+	/**
+	 * Release state machine.
+	 *
+	 * @param machineId the machine id
+	 * @param stop indicating if machine should be stopped
+	 */
+	void releaseStateMachine(String machineId, boolean stop);
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/service/DefaultStateMachineServiceTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/service/DefaultStateMachineServiceTests.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.springframework.context.Lifecycle;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.statemachine.AbstractStateMachineTests;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineSystemConstants;
+import org.springframework.statemachine.config.EnableStateMachineFactory;
+import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.statemachine.config.builders.StateMachineConfigurationConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+
+/**
+ * Tests for {@link DefaultStateMachineService}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@SuppressWarnings("unchecked")
+public class DefaultStateMachineServiceTests extends AbstractStateMachineTests {
+
+	@Override
+	protected AnnotationConfigApplicationContext buildContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+
+	@Test
+	public void testAcquireNotStarted() {
+		context.register(Config1.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", false);
+		assertThat(((Lifecycle)machine1).isRunning(), is(false));
+	}
+
+	@Test
+	public void testAcquireStarted() {
+		context.register(Config1.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", true);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+	}
+
+	@Test
+	public void testReleaseStopMachine() {
+		context.register(Config1.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", true);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+		service.releaseStateMachine("m1");
+		assertThat(((Lifecycle)machine1).isRunning(), is(false));
+	}
+
+	@Test
+	public void testReleaseDoesNotStopMachine() {
+		context.register(Config1.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", true);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+		service.releaseStateMachine("m1", false);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+	}
+
+	@Test
+	public void testAcquireNotStartedThreading() {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", false);
+		assertThat(((Lifecycle)machine1).isRunning(), is(false));
+	}
+
+	@Test
+	public void testAcquireStartedThreading() {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", true);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+	}
+
+	@Test
+	public void testReleaseStopsMachineThreading() {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", true);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+		service.releaseStateMachine("m1");
+		assertThat(((Lifecycle)machine1).isRunning(), is(false));
+	}
+
+	@Test
+	public void testReleaseDoesNotStopMachineThreading() {
+		context.register(Config2.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", true);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+		service.releaseStateMachine("m1", false);
+		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+	}
+
+	@Configuration
+	@EnableStateMachineFactory
+	static class Config1 extends EnumStateMachineConfigurerAdapter<TestStates, TestEvents> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<TestStates, TestEvents> states) throws Exception {
+			states
+				.withStates()
+					.initial(TestStates.S1)
+					.state(TestStates.S1)
+					.state(TestStates.S2);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<TestStates, TestEvents> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(TestStates.S1)
+					.target(TestStates.S2)
+					.event(TestEvents.E1);
+		}
+	}
+
+	@Configuration
+	@EnableStateMachineFactory
+	static class Config2 extends EnumStateMachineConfigurerAdapter<TestStates, TestEvents> {
+
+		@Override
+		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
+			config
+				.withConfiguration()
+					.taskExecutor(stateMachineTaskExecutor());
+		}
+
+		@Override
+		public void configure(StateMachineStateConfigurer<TestStates, TestEvents> states) throws Exception {
+			states
+				.withStates()
+					.initial(TestStates.S1)
+					.state(TestStates.S1)
+					.state(TestStates.S2);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<TestStates, TestEvents> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source(TestStates.S1)
+					.target(TestStates.S2)
+					.event(TestEvents.E1);
+		}
+
+		@Bean
+		public TaskExecutor stateMachineTaskExecutor() {
+			ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+			executor.setCorePoolSize(4);
+			return executor;
+		}
+
+	}
+}


### PR DESCRIPTION
- Add new interface methods to StateMachineService to ease
  starting and stopping when acquiring or releasing machines.
- Relates to #432