### PR TITLE
Add stop logic to DefaultStateMachineService

### DIFF
--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/service/DefaultStateMachineServiceTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/service/DefaultStateMachineServiceTests.java
@@ -18,6 +18,8 @@ package org.springframework.statemachine.service;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import java.util.Map;
+
 import org.junit.Test;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -28,6 +30,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.StateMachineSystemConstants;
+import org.springframework.statemachine.TestUtils;
 import org.springframework.statemachine.config.EnableStateMachineFactory;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.StateMachineFactory;
@@ -151,6 +154,24 @@ public class DefaultStateMachineServiceTests extends AbstractStateMachineTests {
 		assertThat(((Lifecycle)machine1).isRunning(), is(true));
 		service.releaseStateMachine("m1", false);
 		assertThat(((Lifecycle)machine1).isRunning(), is(true));
+	}
+
+	@Test
+	public void testServiceStop() throws Exception {
+		context.register(Config1.class);
+		context.refresh();
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+
+		DefaultStateMachineService<TestStates, TestEvents> service = new DefaultStateMachineService<>(stateMachineFactory);
+		StateMachine<TestStates,TestEvents> machine1 = service.acquireStateMachine("m1", false);
+		StateMachine<TestStates,TestEvents> machine2 = service.acquireStateMachine("m2", false);
+		assertThat(((Lifecycle)machine1).isRunning(), is(false));
+		assertThat(((Lifecycle)machine2).isRunning(), is(false));
+		Map<?, ?> machines = TestUtils.readField("machines", service);
+		assertThat(machines.size(), is(2));
+		service.destroy();
+		assertThat(machines.size(), is(0));
 	}
 
 	@Configuration


### PR DESCRIPTION
- Now implementing DisposableBean and clearing/stopping
  machines if service is destroyed.
- Relates to #432