### PR TITLE
Fix extended state handling during reset

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -737,7 +737,8 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 			}
 		}
 		if (stateSet && stateMachineContext.getExtendedState() != null) {
-			this.extendedState = stateMachineContext.getExtendedState();
+			this.extendedState.getVariables().clear();
+			this.extendedState.getVariables().putAll(stateMachineContext.getExtendedState().getVariables());
 		}
 		if (currentState instanceof Lifecycle) {
 			((Lifecycle)currentState).start();


### PR DESCRIPTION
- Instead of changing extended state object, use existing one
  by clearing it and setting new values from context.
- Fixes #447