### PR TITLE
Allow to define extended state variables during persist

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/Function.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/Function.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.support;
+
+/**
+ * Mimics Java 8's Function interface to allow deferring a computation.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ */
+public interface Function<T, R> {
+
+	/**
+	 * Applies this function to the given argument.
+	 *
+	 * @param t the function argument
+	 * @return the function result
+	 */
+	R apply(T t);
+}


### PR DESCRIPTION
- Now in AbstractPersistingStateMachineInterceptor it is possible
  to use a Function to define which variables are persisted. This
  is for cases where it is not desirable to persist some variables
  for variours reasons.
- Relates to #423