### PR TITLE
JPA entity changes

### DIFF
--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryAction.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 import org.springframework.statemachine.data.RepositoryAction;
 
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
+@Table(name = "Action")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryAction extends RepositoryAction {
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryGuard.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryGuard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 
 import org.springframework.statemachine.data.RepositoryGuard;
 
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
+@Table(name = "Guard")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryGuard extends RepositoryGuard {
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryState.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,19 @@ package org.springframework.statemachine.data.jpa;
 
 import java.util.Set;
 
+import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import org.springframework.statemachine.data.RepositoryAction;
 import org.springframework.statemachine.data.RepositoryState;
@@ -40,6 +45,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
+@Table(name = "State")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryState extends RepositoryState {
 
@@ -55,21 +61,28 @@ public class JpaRepositoryState extends RepositoryState {
 	private String submachineId;
 
 	@OneToOne(fetch = FetchType.EAGER)
+	@JoinColumn(foreignKey = @ForeignKey(name = "fk_state_initial_action"))
 	private JpaRepositoryAction initialAction;
 
 	@OneToOne(fetch = FetchType.EAGER)
+	@JoinColumn(foreignKey = @ForeignKey(name = "fk_state_parent_state"))
 	private JpaRepositoryState parentState;
 
 	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(foreignKey = @ForeignKey(name = "fk_state_state_actions_s"), inverseForeignKey = @ForeignKey(name = "fk_state_state_actions_a"))
 	private Set<JpaRepositoryAction> stateActions;
 
 	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(foreignKey = @ForeignKey(name = "fk_state_entry_actions_s"), inverseForeignKey = @ForeignKey(name = "fk_state_entry_actions_a"))
 	private Set<JpaRepositoryAction> entryActions;
 
 	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(foreignKey = @ForeignKey(name = "fk_state_exit_actions_s"), inverseForeignKey = @ForeignKey(name = "fk_state_exit_actions_a"))
 	private Set<JpaRepositoryAction> exitActions;
 
 	@ElementCollection(fetch = FetchType.EAGER, targetClass = String.class)
+	@CollectionTable(name="DeferredEvents")
+	@JoinColumn(foreignKey = @ForeignKey(name = "fk_state_deferred_events"))
 	private Set<String> deferredEvents;
 
 	/**

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachine.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.statemachine.data.jpa;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Lob;
+import javax.persistence.Table;
 
 import org.springframework.statemachine.data.RepositoryStateMachine;
 
@@ -31,6 +32,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
+@Table(name = "StateMachine")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryStateMachine extends RepositoryStateMachine {
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryTransition.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@ import java.util.Set;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import org.springframework.statemachine.data.RepositoryTransition;
 import org.springframework.statemachine.transition.TransitionKind;
@@ -38,6 +42,7 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
+@Table(name = "Transition")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryTransition extends RepositoryTransition {
 
@@ -48,18 +53,22 @@ public class JpaRepositoryTransition extends RepositoryTransition {
 	private String machineId;
 
 	@OneToOne(fetch = FetchType.EAGER)
+	@JoinColumn(foreignKey = @ForeignKey(name = "fk_transition_source"))
 	private JpaRepositoryState source;
 
 	@OneToOne(fetch = FetchType.EAGER)
+	@JoinColumn(foreignKey = @ForeignKey(name = "fk_transition_target"))
 	private JpaRepositoryState target;
 
 	private String event;
 	private TransitionKind kind;
 
 	@ManyToMany(fetch = FetchType.EAGER)
+	@JoinTable(foreignKey = @ForeignKey(name = "fk_transition_actions_t"), inverseForeignKey = @ForeignKey(name = "fk_transition_actions_a"))
 	private Set<JpaRepositoryAction> actions;
 
 	@OneToOne(fetch = FetchType.EAGER)
+	@JoinColumn(foreignKey = @ForeignKey(name = "fk_transition_guard"))
 	private JpaRepositoryGuard guard;
 
 	/**


### PR DESCRIPTION
- Modify existing JPA entity classes to
  have a fixed names for constraints and
  foreign key. Also name used tables so that
  we don't get crazy long names which are
  causing issues with some DB's
- Fixes #468
- Fixes #469