### PR TITLE
Change JPA initial state field

### DIFF
--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryState.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryState.java
@@ -18,6 +18,7 @@ package org.springframework.statemachine.data.jpa;
 import java.util.Set;
 
 import javax.persistence.CollectionTable;
+import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -56,6 +57,8 @@ public class JpaRepositoryState extends RepositoryState {
 	private String machineId;
 	private String state;
 	private String region;
+
+	@Column(name = "initialState")
 	private boolean initial;
 	private PseudoStateKind kind;
 	private String submachineId;


### PR DESCRIPTION
- Change initial field to initialState which
  resolves initial reserved keywork problem.
- Fixes #472