### PR TITLE
Fix uml spel state action

### DIFF
--- a/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
+++ b/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -500,7 +500,7 @@ public class UmlModelParser {
 							new SpelParserConfiguration(SpelCompilerMode.MIXED, null));
 					ArrayList<Action<String, String>> stateActions = new ArrayList<Action<String, String>>();
 					stateActions.add(new SpelExpressionAction<String, String>(parser.parseExpression(expression)));
-					stateData.setExitActions(stateActions);
+					stateData.setStateActions(stateActions);
 				}
 			}
 		}

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-actions.notation
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-actions.notation
@@ -49,6 +49,10 @@
               <element xmi:type="uml:FunctionBehavior" href="simple-actions.uml#_Pk2SMASYEeaXyaQL1WyV3A"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_Pk_cIQSYEeaXyaQL1WyV3A"/>
             </children>
+            <children xmi:type="notation:Shape" xmi:id="_tUbu8PzjEeeuv4NiH5yIZg" type="691">
+              <element xmi:type="uml:FunctionBehavior" href="simple-actions.uml#_tSJ3APzjEeeuv4NiH5yIZg"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_tUbu8fzjEeeuv4NiH5yIZg"/>
+            </children>
             <element xmi:type="uml:State" href="simple-actions.uml#_s9CwsASXEeaXyaQL1WyV3A"/>
             <layoutConstraint xmi:type="notation:Bounds" xmi:id="_s9FM8QSXEeaXyaQL1WyV3A" x="230" y="207" width="261" height="61"/>
           </children>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-actions.uml
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/simple-actions.uml
@@ -17,6 +17,10 @@
         </exit>
       </subvertex>
       <subvertex xmi:type="uml:State" xmi:id="_s9CwsASXEeaXyaQL1WyV3A" name="S2">
+        <doActivity xmi:type="uml:FunctionBehavior" xmi:id="_tSJ3APzjEeeuv4NiH5yIZg">
+          <language>spel</language>
+          <body>extendedState.variables.put('hellos2do','hellos2dovalue')</body>
+        </doActivity>
         <entry xmi:type="uml:FunctionBehavior" xmi:id="_Pk2SMASYEeaXyaQL1WyV3A" name="s2Entry">
           <language>bean</language>
           <body>s2Entry</body>


### PR DESCRIPTION
- UmlModelParser wrongly set spel based state action as
  exit action. Change this to behave same as bean based
  action is used.
- Fixes #474