### PR TITLE
Fix typo in transition conflict

### DIFF
--- a/docs/src/reference/asciidoc/sm.adoc
+++ b/docs/src/reference/asciidoc/sm.adoc
@@ -454,6 +454,9 @@ this decision to a user whether a machine should be started
 automatically or not. This flag will only control an autostart of a
 top-level state machine.
 
+Setting `machineId` within a configuration is simply a convenience if
+user wants or needs to do it here.
+
 Setting a `BeanFactory`, `TaskExecutor` or `TaskScheduler` exist for
 convenience for a user and are also use within a framework itself.
 
@@ -463,6 +466,13 @@ state machine lifecycle like getting notified of a state machine
 start/stop events. Naturally it is not possible to listen a state
 machine start events if `autoStartup` is enabled unless listener can
 be registered during a configuration phase.
+
+`transitionConflictPolicy` can be used in cases where multiple
+transition paths could be selected. One usual use case for this is if
+machine contains anonymous transitions leading out from a sub-state
+and a parent state and user want to define a policy which one will be
+selected. This is a global setting within a machine instance and
+default to _CHILD_.
 
 `DistributedStateMachine` is configured via `withDistributed()` which
 allows to set a `StateMachineEnsemble` which if exists automatically

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/ObjectStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/ObjectStateMachineFactory.java
@@ -76,7 +76,7 @@ public class ObjectStateMachineFactory<S, E> extends AbstractStateMachineFactory
 				extendedState, uuid);
 		machine.setId(machineId);
 		machine.setHistoryState(historyState);
-		machine.setTransitionConflightPolicy(stateMachineModel.getConfigurationData().getTransitionConflightPolicy());
+		machine.setTransitionConflightPolicy(stateMachineModel.getConfigurationData().getTransitionConflictPolicy());
 		if (contextEventsEnabled != null) {
 			machine.setContextEventsEnabled(contextEventsEnabled);
 		}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ import org.springframework.statemachine.monitor.StateMachineMonitor;
 import org.springframework.statemachine.persist.StateMachineRuntimePersister;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.support.StateMachineInterceptor;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 
 /**
  * {@link AnnotationBuilder} for {@link StatesData}.
@@ -65,7 +65,7 @@ public class StateMachineConfigurationBuilder<S, E>
 	private TaskExecutor taskExecutor;
 	private TaskScheduler taskScheculer;
 	private boolean autoStart = false;
-	private TransitionConflightPolicy transitionConflightPolicy;
+	private TransitionConflictPolicy transitionConflictPolicy;
 	private StateMachineEnsemble<S, E> ensemble;
 	private final List<StateMachineListener<S, E>> listeners = new ArrayList<StateMachineListener<S, E>>();
 	private boolean securityEnabled = false;
@@ -147,7 +147,7 @@ public class StateMachineConfigurationBuilder<S, E>
 		}
 		return new ConfigurationData<S, E>(beanFactory, taskExecutor, taskScheculer, autoStart, ensemble, listeners,
 				securityEnabled, transitionSecurityAccessDecisionManager, eventSecurityAccessDecisionManager, eventSecurityRule,
-				transitionSecurityRule, verifierEnabled, verifier, machineId, stateMachineMonitor, interceptorsCopy, transitionConflightPolicy);
+				transitionSecurityRule, verifierEnabled, verifier, machineId, stateMachineMonitor, interceptorsCopy, transitionConflictPolicy);
 	}
 
 	/**
@@ -296,11 +296,11 @@ public class StateMachineConfigurationBuilder<S, E>
 	}
 
 	/**
-	 * Sets the transition conflight policy.
+	 * Sets the transition conflict policy.
 	 *
-	 * @param transitionConflightPolicy the new transition conflight policy
+	 * @param transitionConflictPolicy the new transition conflict policy
 	 */
-	public void setTransitionConflightPolicy(TransitionConflightPolicy transitionConflightPolicy) {
-		this.transitionConflightPolicy = transitionConflightPolicy;
+	public void setTransitionConflictPolicy(TransitionConflictPolicy transitionConflictPolicy) {
+		this.transitionConflictPolicy = transitionConflictPolicy;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ConfigurationConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ConfigurationConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.config.builders.StateMachineConfigurationConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerBuilder;
 import org.springframework.statemachine.listener.StateMachineListener;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 
 /**
  * Base {@code ConfigConfigurer} interface for configuring generic config.
@@ -88,10 +88,10 @@ public interface ConfigurationConfigurer<S, E> extends
 	ConfigurationConfigurer<S, E> listener(StateMachineListener<S, E> listener);
 
 	/**
-	 * Speficy a {@link TransitionConflightPolicy}.
+	 * Speficy a {@link TransitionConflictPolicy}. Default to {@link TransitionConflictPolicy#CHILD}.
 	 *
-	 * @param transitionConflightPolicy the transition conflight policy
+	 * @param transitionConflictPolicy the transition conflict policy
 	 * @return the configuration configurer
 	 */
-	ConfigurationConfigurer<S, E> transitionConflightPolicy(TransitionConflightPolicy transitionConflightPolicy);
+	ConfigurationConfigurer<S, E> transitionConflictPolicy(TransitionConflictPolicy transitionConflictPolicy);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultConfigurationConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultConfigurationConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.springframework.statemachine.config.builders.StateMachineConfiguratio
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerAdapter;
 import org.springframework.statemachine.config.model.ConfigurationData;
 import org.springframework.statemachine.listener.StateMachineListener;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 
 /**
  * Default implementation of a {@link ConfigurationConfigurer}.
@@ -45,7 +45,7 @@ public class DefaultConfigurationConfigurer<S, E>
 	private TaskExecutor taskExecutor;
 	private TaskScheduler taskScheculer;
 	private boolean autoStart = false;
-	private TransitionConflightPolicy transitionConflightPolicy;
+	private TransitionConflictPolicy transitionConflightPolicy;
 	private final List<StateMachineListener<S, E>> listeners = new ArrayList<StateMachineListener<S, E>>();
 
 	@Override
@@ -56,7 +56,7 @@ public class DefaultConfigurationConfigurer<S, E>
 		builder.setTaskScheculer(taskScheculer);
 		builder.setAutoStart(autoStart);
 		builder.setStateMachineListeners(listeners);
-		builder.setTransitionConflightPolicy(transitionConflightPolicy);
+		builder.setTransitionConflictPolicy(transitionConflightPolicy);
 	}
 
 	@Override
@@ -96,7 +96,7 @@ public class DefaultConfigurationConfigurer<S, E>
 	}
 
 	@Override
-	public ConfigurationConfigurer<S, E> transitionConflightPolicy(TransitionConflightPolicy transitionConflightPolicy) {
+	public ConfigurationConfigurer<S, E> transitionConflictPolicy(TransitionConflictPolicy transitionConflightPolicy) {
 		this.transitionConflightPolicy = transitionConflightPolicy;
 		return this;
 	}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ConfigurationData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ConfigurationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.springframework.statemachine.listener.StateMachineListener;
 import org.springframework.statemachine.monitor.StateMachineMonitor;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.support.StateMachineInterceptor;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 
 /**
  * Configuration object used to keep things together in {@link StateMachineConfigurationBuilder}.
@@ -49,7 +49,7 @@ public class ConfigurationData<S, E> {
 	private final TaskExecutor taskExecutor;
 	private final TaskScheduler taskScheduler;
 	private final boolean autoStart;
-	private final TransitionConflightPolicy transitionConflightPolicy;
+	private final TransitionConflictPolicy transitionConflictPolicy;
 	private final StateMachineEnsemble<S, E> ensemble;
 	private final List<StateMachineListener<S, E>> listeners;
 	private final boolean securityEnabled;
@@ -121,7 +121,7 @@ public class ConfigurationData<S, E> {
 	 * @param machineId the machine id
 	 * @param stateMachineMonitor the state machine monitor
 	 * @param interceptors the state machine interceptors.
-	 * @param transitionConflightPolicy the transition conflight policy
+	 * @param transitionConflightPolicy the transition conflict policy
 	 */
 	public ConfigurationData(BeanFactory beanFactory, TaskExecutor taskExecutor,
 			TaskScheduler taskScheduler, boolean autoStart, StateMachineEnsemble<S, E> ensemble,
@@ -129,7 +129,7 @@ public class ConfigurationData<S, E> {
 			AccessDecisionManager transitionSecurityAccessDecisionManager, AccessDecisionManager eventSecurityAccessDecisionManager,
 			SecurityRule eventSecurityRule, SecurityRule transitionSecurityRule, boolean verifierEnabled,
 			StateMachineModelVerifier<S, E> verifier, String machineId, StateMachineMonitor<S, E> stateMachineMonitor,
-			List<StateMachineInterceptor<S, E>> interceptors, TransitionConflightPolicy transitionConflightPolicy) {
+			List<StateMachineInterceptor<S, E>> interceptors, TransitionConflictPolicy transitionConflightPolicy) {
 		this.beanFactory = beanFactory;
 		this.taskExecutor = taskExecutor;
 		this.taskScheduler = taskScheduler;
@@ -146,7 +146,7 @@ public class ConfigurationData<S, E> {
 		this.machineId = machineId;
 		this.stateMachineMonitor = stateMachineMonitor;
 		this.interceptors = interceptors;
-		this.transitionConflightPolicy = transitionConflightPolicy;
+		this.transitionConflictPolicy = transitionConflightPolicy;
 	}
 
 	public String getMachineId() {
@@ -289,11 +289,11 @@ public class ConfigurationData<S, E> {
 	}
 
 	/**
-	 * Gets the transition conflight policy.
+	 * Gets the transition conflict policy.
 	 *
-	 * @return the transition conflight policy
+	 * @return the transition conflict policy
 	 */
-	public TransitionConflightPolicy getTransitionConflightPolicy() {
-		return transitionConflightPolicy;
+	public TransitionConflictPolicy getTransitionConflictPolicy() {
+		return transitionConflictPolicy;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -52,7 +52,7 @@ import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.support.StateMachineExecutor.StateMachineExecutorTransit;
 import org.springframework.statemachine.transition.InitialTransition;
 import org.springframework.statemachine.transition.Transition;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 import org.springframework.statemachine.transition.TransitionKind;
 import org.springframework.statemachine.trigger.DefaultTriggerContext;
 import org.springframework.statemachine.trigger.Trigger;
@@ -93,7 +93,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 
 	private ExtendedState extendedState;
 
-	private TransitionConflightPolicy transitionConflightPolicy;
+	private TransitionConflictPolicy transitionConflictPolicy;
 
 	private volatile State<S,E> currentState;
 
@@ -273,7 +273,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		}
 
 		DefaultStateMachineExecutor<S, E> executor = new DefaultStateMachineExecutor<S, E>(this, getRelayStateMachine(), transitions,
-				triggerToTransitionMap, triggerlessTransitions, initialTransition, initialEvent, transitionConflightPolicy);
+				triggerToTransitionMap, triggerlessTransitions, initialTransition, initialEvent, transitionConflictPolicy);
 		if (getBeanFactory() != null) {
 			executor.setBeanFactory(getBeanFactory());
 		}
@@ -567,12 +567,12 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 	}
 
 	/**
-	 * Sets the transition conflight policy.
+	 * Sets the transition conflict policy.
 	 *
-	 * @param transitionConflightPolicy the new transition conflight policy
+	 * @param transitionConflictPolicy the new transition conflict policy
 	 */
-	public void setTransitionConflightPolicy(TransitionConflightPolicy transitionConflightPolicy) {
-		this.transitionConflightPolicy = transitionConflightPolicy;
+	public void setTransitionConflightPolicy(TransitionConflictPolicy transitionConflictPolicy) {
+		this.transitionConflictPolicy = transitionConflictPolicy;
 	}
 
 	private boolean sendEventInternal(Message<E> event) {

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
@@ -47,7 +47,7 @@ import org.springframework.statemachine.state.JoinPseudoState;
 import org.springframework.statemachine.state.PseudoStateKind;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.transition.Transition;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 import org.springframework.statemachine.trigger.DefaultTriggerContext;
 import org.springframework.statemachine.trigger.TimerTrigger;
 import org.springframework.statemachine.trigger.Trigger;
@@ -114,12 +114,12 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 	 * @param triggerlessTransitions the triggerless transitions
 	 * @param initialTransition the initial transition
 	 * @param initialEvent the initial event
-	 * @param transitionConflightPolicy the transition conflight policy
+	 * @param transitionConflictPolicy the transition conflict policy
 	 */
 	public DefaultStateMachineExecutor(StateMachine<S, E> stateMachine, StateMachine<S, E> relayStateMachine,
 			Collection<Transition<S, E>> transitions, Map<Trigger<S, E>, Transition<S, E>> triggerToTransitionMap,
 			List<Transition<S, E>> triggerlessTransitions, Transition<S, E> initialTransition, Message<E> initialEvent,
-			TransitionConflightPolicy transitionConflightPolicy) {
+			TransitionConflictPolicy transitionConflictPolicy) {
 		this.stateMachine = stateMachine;
 		this.relayStateMachine = relayStateMachine;
 		this.triggerToTransitionMap = triggerToTransitionMap;
@@ -127,7 +127,7 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 		this.transitions = transitions;
 		this.initialTransition = initialTransition;
 		this.initialEvent = initialEvent;
-		this.transitionComparator = new TransitionComparator<S, E>(transitionConflightPolicy);
+		this.transitionComparator = new TransitionComparator<S, E>(transitionConflictPolicy);
 		// anonymous transitions are fixed, sort those now
 		this.triggerlessTransitions.sort(transitionComparator);
 		registerTriggerListener();

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/TransitionComparator.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/TransitionComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Comparator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.statemachine.transition.Transition;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 
 /**
  * {@link Comparator} for {@link Transition}s. This comparator tries to compare
@@ -34,15 +34,15 @@ import org.springframework.statemachine.transition.TransitionConflightPolicy;
 class TransitionComparator<S, E> implements Comparator<Transition<S, E>> {
 
 	private final static Log log = LogFactory.getLog(TransitionComparator.class);
-	private final TransitionConflightPolicy transitionConflightPolicy;
+	private final TransitionConflictPolicy transitionConflictPolicy;
 
 	/**
 	 * Instantiates a new transition comparator.
 	 *
-	 * @param transitionConflightPolicy the transition conflight policy
+	 * @param transitionConflictPolicy the transition conflict policy
 	 */
-	public TransitionComparator(TransitionConflightPolicy transitionConflightPolicy) {
-		this.transitionConflightPolicy = transitionConflightPolicy == null ? TransitionConflightPolicy.CHILD : transitionConflightPolicy;
+	public TransitionComparator(TransitionConflictPolicy transitionConflictPolicy) {
+		this.transitionConflictPolicy = transitionConflictPolicy == null ? TransitionConflictPolicy.CHILD : transitionConflictPolicy;
 	}
 
 	@Override
@@ -54,7 +54,7 @@ class TransitionComparator<S, E> implements Comparator<Transition<S, E>> {
 			return 0;
 		} else {
 			boolean substate = StateMachineUtils.isSubstate(left.getSource(), right.getSource());
-			if (transitionConflightPolicy == TransitionConflightPolicy.CHILD) {
+			if (transitionConflictPolicy == TransitionConflictPolicy.CHILD) {
 				return substate ? 1 : -1;
 			} else {
 				return substate ? -1 : 1;
@@ -64,6 +64,6 @@ class TransitionComparator<S, E> implements Comparator<Transition<S, E>> {
 
 	@Override
 	public String toString() {
-		return "TransitionComparator [transitionConflightPolicy=" + transitionConflightPolicy + "]";
+		return "TransitionComparator [transitionConflightPolicy=" + transitionConflictPolicy + "]";
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/TransitionConflictPolicy.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/TransitionConflictPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,23 @@
 package org.springframework.statemachine.transition;
 
 /**
- * Enumerations for possible transition conflight policies.
+ * Enumerations for possible transition conflict policies. In case multiple
+ * transitions become possible, thus machine having a need to choose one, these
+ * policies determine if transition is picked from originating child or parent
+ * states.
  *
  * @author Janne Valkealahti
  *
  */
-public enum TransitionConflightPolicy {
+public enum TransitionConflictPolicy {
 
 	/**
-	 * Choose transition from a child.
+	 * Policy choosing transition from a child.
 	 */
 	CHILD,
 
 	/**
-	 * Choose transition from a parent.
+	 * Policy choosing from a parent.
 	 */
 	PARENT;
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.support.StateMachineInterceptor;
 import org.springframework.statemachine.support.StateMachineInterceptorAdapter;
 import org.springframework.statemachine.transition.Transition;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 
 /**
  * Tests for state machine configuration.
@@ -1154,10 +1155,12 @@ public class DocsConfigurationSampleTests extends AbstractStateMachineTests {
 				config
 					.withConfiguration()
 						.autoStartup(true)
+						.machineId("myMachineId")
 						.beanFactory(new StaticListableBeanFactory())
 						.taskExecutor(new SyncTaskExecutor())
 						.taskScheduler(new ConcurrentTaskScheduler())
-						.listener(new StateMachineListenerAdapter<States, Events>());
+						.listener(new StateMachineListenerAdapter<States, Events>())
+						.transitionConflictPolicy(TransitionConflictPolicy.CHILD);
 			}
 		}
 // end::snippetYA[]

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/TransitionComparatorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/TransitionComparatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.state.StateMachineState;
 import org.springframework.statemachine.transition.DefaultExternalTransition;
 import org.springframework.statemachine.transition.Transition;
-import org.springframework.statemachine.transition.TransitionConflightPolicy;
+import org.springframework.statemachine.transition.TransitionConflictPolicy;
 import org.springframework.statemachine.trigger.EventTrigger;
 
 /**
@@ -82,13 +82,13 @@ public class TransitionComparatorTests {
 		assertThat(comparator.compare(transitionFromS111ToS1, transitionFromS111ToS1), is(0));
 		assertThat(comparator.compare(transitionFromS11ToS1, transitionFromS11ToS1), is(0));
 
-		comparator = new TransitionComparator<>(TransitionConflightPolicy.CHILD);
+		comparator = new TransitionComparator<>(TransitionConflictPolicy.CHILD);
 		assertThat(comparator.compare(transitionFromS111ToS1, transitionFromS11ToS1), is(-1));
 		assertThat(comparator.compare(transitionFromS11ToS1, transitionFromS111ToS1), is(1));
 		assertThat(comparator.compare(transitionFromS111ToS1, transitionFromS111ToS1), is(0));
 		assertThat(comparator.compare(transitionFromS11ToS1, transitionFromS11ToS1), is(0));
 
-		comparator = new TransitionComparator<>(TransitionConflightPolicy.PARENT);
+		comparator = new TransitionComparator<>(TransitionConflictPolicy.PARENT);
 		assertThat(comparator.compare(transitionFromS111ToS1, transitionFromS11ToS1), is(1));
 		assertThat(comparator.compare(transitionFromS11ToS1, transitionFromS111ToS1), is(-1));
 		assertThat(comparator.compare(transitionFromS111ToS1, transitionFromS111ToS1), is(0));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionOrderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionOrderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -221,7 +221,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.PARENT);
+					.transitionConflictPolicy(TransitionConflictPolicy.PARENT);
 		}
 
 		@Override
@@ -264,7 +264,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.PARENT);
+					.transitionConflictPolicy(TransitionConflictPolicy.PARENT);
 		}
 
 		@Override
@@ -307,7 +307,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.CHILD);
+					.transitionConflictPolicy(TransitionConflictPolicy.CHILD);
 		}
 
 		@Override
@@ -349,7 +349,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.PARENT);
+					.transitionConflictPolicy(TransitionConflictPolicy.PARENT);
 		}
 
 		@Override
@@ -393,7 +393,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.PARENT);
+					.transitionConflictPolicy(TransitionConflictPolicy.PARENT);
 		}
 
 		@Override
@@ -436,7 +436,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.PARENT);
+					.transitionConflictPolicy(TransitionConflictPolicy.PARENT);
 		}
 
 		@Override
@@ -483,7 +483,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.CHILD);
+					.transitionConflictPolicy(TransitionConflictPolicy.CHILD);
 		}
 
 		@Override
@@ -530,7 +530,7 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		public void configure(StateMachineConfigurationConfigurer<TestStates, TestEvents> config) throws Exception {
 			config
 				.withConfiguration()
-					.transitionConflightPolicy(TransitionConflightPolicy.PARENT);
+					.transitionConflictPolicy(TransitionConflictPolicy.PARENT);
 		}
 
 		@Override


### PR DESCRIPTION
- Changing unfortunate typo conflight vs. conflict.
- Also add some docs for transition conflict.
- Relates to #456
- Relates to #476