### PR TITLE
Add hamcrest integration to variables in StateMachineTestPlanBuilder

### DIFF
--- a/docs/src/reference/asciidoc/sm.adoc
+++ b/docs/src/reference/asciidoc/sm.adoc
@@ -2064,6 +2064,13 @@ state machine features and multiple machines can be added to a plan.
 If multiple machines are added then it is also possible to choose if
 event is sent to particular, random or all machines.
 
+Above testing example uses hamcrest imports:
+
+[source,java,indent=0]
+----
+include::samples/DocsTestSampleTests.java[tags=snippetC]
+----
+
 [TIP]
 ====
 All possible options for expected are documented in javadocs

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/StateMachineTestPlan.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/StateMachineTestPlan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,6 +264,15 @@ public class StateMachineTestPlan<S, E> {
 					for (Object key : step.expectVariableKeys) {
 						assertThat("Key " + key + " doesn't exist in extended state variables",
 								variables.containsKey(key), is(true));
+					}
+				}
+			}
+
+			if (!step.expectVariableKeysMatchers.isEmpty()) {
+				for (StateMachine<S, E> stateMachine : stateMachines.values()) {
+					Map<Object, Object> variables = stateMachine.getExtendedState().getVariables();
+					for (Matcher<Map<? extends Object, ?>> matcher : step.expectVariableKeysMatchers) {
+						org.hamcrest.MatcherAssert.assertThat(variables, matcher);
 					}
 				}
 			}

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/StateMachineTestPlanBuilder.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/StateMachineTestPlanBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.hamcrest.Matcher;
 import org.springframework.messaging.Message;
 import org.springframework.statemachine.StateMachine;
 
@@ -129,8 +130,8 @@ public class StateMachineTestPlanBuilder<S, E> {
 		Integer expectStateMachineStopped;
 		Integer expectExtendedStateChanged;
 		final Collection<Object> expectVariableKeys = new ArrayList<Object>();
+		final Collection<Matcher<Map<? extends Object, ?>>> expectVariableKeysMatchers = new ArrayList<>();
 		final Map<Object, Object> expectVariables = new HashMap<Object, Object>();
-
 
 		/**
 		 * Expect a state {@code S}.
@@ -249,6 +250,7 @@ public class StateMachineTestPlanBuilder<S, E> {
 		 * by {@code machineId}. Multiple events can be defined which are then
 		 * send in defined order.
 		 *
+		 *
 		 * @param event the event
 		 * @param machineId the machine identifier for sending event
 		 * @return the state machine test plan step builder
@@ -267,6 +269,17 @@ public class StateMachineTestPlanBuilder<S, E> {
 		 */
 		public StateMachineTestPlanStepBuilder expectVariable(Object key) {
 			this.expectVariableKeys.add(key);
+			return this;
+		}
+
+		/**
+		 * Expect variable map with hamcrest {@link Matcher}.
+		 *
+		 * @param matcher the matcher
+		 * @return the state machine test plan step builder
+		 */
+		public StateMachineTestPlanStepBuilder expectVariableMatcher(Matcher<Map<? extends Object, ?>> matcher) {
+			this.expectVariableKeysMatchers.add(matcher);
 			return this;
 		}
 
@@ -458,8 +471,9 @@ public class StateMachineTestPlanBuilder<S, E> {
 			steps.add(new StateMachineTestPlanStep<S, E>(sendEvent, sendMessage, sendEventMachineId, sendEventToAll,
 					sendEventParallel, expectStates, expectStateChanged, expectStateEntered, expectStateExited,
 					expectEventNotAccepted, expectTransition, expectTransitionStarted, expectTransitionEnded,
-					expectStateMachineStarted, expectStateMachineStopped, expectVariableKeys, expectVariables,
-					expectExtendedStateChanged, expectStatesEntrered, expectStatesExited));
+					expectStateMachineStarted, expectStateMachineStopped, expectVariableKeys,
+					expectVariableKeysMatchers, expectVariables, expectExtendedStateChanged,
+					expectStatesEntrered, expectStatesExited));
 			return StateMachineTestPlanBuilder.this;
 		}
 
@@ -485,6 +499,7 @@ public class StateMachineTestPlanBuilder<S, E> {
 		Integer expectStateMachineStopped;
 		Integer expectExtendedStateChanged;
 		final Collection<Object> expectVariableKeys;
+		final Collection<Matcher<Map<? extends Object, ?>>> expectVariableKeysMatchers;
 		final Map<Object, Object> expectVariables;
 
 		public StateMachineTestPlanStep(List<E> sendEvent, List<Message<E>> sendMessage, Object sendEventMachineId,
@@ -492,8 +507,10 @@ public class StateMachineTestPlanBuilder<S, E> {
 				Integer expectStateChanged, Integer expectStateEntered, Integer expectStateExited,
 				Integer expectEventNotAccepted, Integer expectTransition, Integer expectTransitionStarted,
 				Integer expectTransitionEnded, Integer expectStateMachineStarted, Integer expectStateMachineStopped,
-				Collection<Object> expectVariableKeys, Map<Object, Object> expectVariables,
-				Integer expectExtendedStateChanged, Collection<S> expectStatesEntrered, Collection<S> expectStatesExited) {
+				Collection<Object> expectVariableKeys, Collection<Matcher<Map<? extends Object, ?>>> expectVariableKeysMatchers,
+				Map<Object, Object> expectVariables,
+				Integer expectExtendedStateChanged, Collection<S> expectStatesEntrered,
+				Collection<S> expectStatesExited) {
 			this.sendEvent = sendEvent;
 			this.sendMessage = sendMessage;
 			this.sendEventMachineId = sendEventMachineId;
@@ -510,6 +527,7 @@ public class StateMachineTestPlanBuilder<S, E> {
 			this.expectStateMachineStarted = expectStateMachineStarted;
 			this.expectStateMachineStopped = expectStateMachineStopped;
 			this.expectVariableKeys = expectVariableKeys;
+			this.expectVariableKeysMatchers = expectVariableKeysMatchers;
 			this.expectVariables = expectVariables;
 			this.expectExtendedStateChanged = expectExtendedStateChanged;
 			this.expectStatesEntrered = expectStatesEntrered;

--- a/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/StateMachineTestingTests.java
+++ b/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/StateMachineTestingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 package org.springframework.statemachine.test;
 
+import static org.hamcrest.CoreMatchers.not;
+
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -100,6 +103,48 @@ public class StateMachineTestingTests extends AbstractStateMachineTests {
 					.step().expectState("SI").and()
 					.step().sendEvent("E1").expectStateChanged(1).expectState("S1").and()
 					.step().sendEvent("E2").expectStateChanged(2).expectStateEntered("S2", "S3").expectStateExited("S1", "S2").expectState("S3").and()
+					.build();
+
+		plan.test();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testVariables() throws Exception {
+		registerAndRefresh(Config5.class);
+		StateMachine<String, String> machine =	context.getBean(StateMachine.class);
+
+		StateMachineTestPlan<String, String> plan =
+				StateMachineTestPlanBuilder.<String, String>builder()
+					.stateMachine(machine)
+					.step().expectStateMachineStarted(1).and()
+					.step().expectState("SI").and()
+					.step()
+						.sendEvent("E1")
+						.expectStateChanged(1)
+						.expectState("S1")
+						.expectVariable("V1Key")
+						.expectVariable("V1Key", "V1Value")
+						.expectVariableMatcher(IsMapContaining.hasKey("V1Key"))
+						.expectVariableMatcher(IsMapContaining.hasValue("V1Value"))
+						.expectVariableMatcher(IsMapContaining.hasEntry("V1Key", "V1Value"))
+						.expectVariableMatcher(not(IsMapContaining.hasKey("V2Key")))
+						.and()
+					.step()
+						.sendEvent("E2")
+						.expectStateChanged(1)
+						.expectState("S2")
+						.expectVariable("V1Key")
+						.expectVariable("V1Key", "V1Value")
+						.expectVariable("V2Key")
+						.expectVariable("V2Key", "V2Value")
+						.expectVariableMatcher(IsMapContaining.hasKey("V1Key"))
+						.expectVariableMatcher(IsMapContaining.hasValue("V1Value"))
+						.expectVariableMatcher(IsMapContaining.hasEntry("V1Key", "V1Value"))
+						.expectVariableMatcher(IsMapContaining.hasKey("V2Key"))
+						.expectVariableMatcher(IsMapContaining.hasValue("V2Value"))
+						.expectVariableMatcher(IsMapContaining.hasEntry("V2Key", "V2Value"))
+						.and()
 					.build();
 
 		plan.test();
@@ -246,4 +291,37 @@ public class StateMachineTestingTests extends AbstractStateMachineTests {
 
 	}
 
+	@Configuration
+	@EnableStateMachine
+	static class Config5 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("SI")
+					.state("S1")
+					.state("S2");
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("SI")
+					.target("S1")
+					.event("E1")
+					.action(c -> {
+						c.getExtendedState().getVariables().put("V1Key", "V1Value");
+					})
+					.and()
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E2")
+					.action(c -> {
+						c.getExtendedState().getVariables().put("V2Key", "V2Value");
+					});
+		}
+	}
 }

--- a/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/docs/DocsTestSampleTests.java
+++ b/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/docs/DocsTestSampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 package org.springframework.statemachine.test.docs;
+
+//tag::snippetC[]
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
+import static org.hamcrest.collection.IsMapContaining.hasValue;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+//end::snippetC[]
 
 import org.junit.Test;
 import org.springframework.core.task.SyncTaskExecutor;
@@ -39,6 +46,12 @@ public class DocsTestSampleTests {
 						.sendEvent("E1")
 						.expectStateChanged(1)
 						.expectStates("S1")
+						.expectVariable("key1")
+						.expectVariable("key1", "value1")
+						.expectVariableMatcher(hasKey("key1"))
+						.expectVariableMatcher(hasValue("value1"))
+						.expectVariableMatcher(hasEntry("key1", "value1"))
+						.expectVariableMatcher(not(hasKey("key2")))
 						.and()
 					.build();
 		plan.test();
@@ -62,7 +75,10 @@ public class DocsTestSampleTests {
 		builder.configureTransitions()
 				.withExternal()
 					.source("SI").target("S1")
-					.event("E1");
+					.event("E1")
+					.action(c -> {
+						c.getExtendedState().getVariables().put("key1", "value1");
+					});
 
 		return builder.build();
 	}


### PR DESCRIPTION
- For testing extended state variables, it's now possible to use
  new method expectVariableMatcher which takes hamcrest matcher
  as an argument.
- Fixes #483