### PR TITLE
Use the contextObj as is when saving the StateMachineContext

### DIFF
--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachinePersist.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachinePersist.java
@@ -60,7 +60,7 @@ public class JpaRepositoryStateMachinePersist<S, E> extends RepositoryStateMachi
 	}
 
 	@Override
-	protected JpaRepositoryStateMachine build(StateMachineContext<S, E> context, byte[] serialisedContext) {
+	protected JpaRepositoryStateMachine build(StateMachineContext<S, E> context, Object contextObj, byte[] serialisedContext) {
 		JpaRepositoryStateMachine jpaRepositoryStateMachine = new JpaRepositoryStateMachine();
 		jpaRepositoryStateMachine.setMachineId(context.getId());
 		jpaRepositoryStateMachine.setState(context.getState().toString());

--- a/spring-statemachine-data/mongodb/src/main/java/org/springframework/statemachine/data/mongodb/MongoDbRepositoryStateMachine.java
+++ b/spring-statemachine-data/mongodb/src/main/java/org/springframework/statemachine/data/mongodb/MongoDbRepositoryStateMachine.java
@@ -35,6 +35,14 @@ public class MongoDbRepositoryStateMachine extends RepositoryStateMachine {
 	private String state;
 	private byte[] stateMachineContext;
 
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	@Override
 	public String getMachineId() {
 		return machineId;

--- a/spring-statemachine-data/mongodb/src/main/java/org/springframework/statemachine/data/mongodb/MongoDbRepositoryStateMachinePersist.java
+++ b/spring-statemachine-data/mongodb/src/main/java/org/springframework/statemachine/data/mongodb/MongoDbRepositoryStateMachinePersist.java
@@ -60,8 +60,9 @@ public class MongoDbRepositoryStateMachinePersist<S, E> extends RepositoryStateM
 	}
 
 	@Override
-	protected MongoDbRepositoryStateMachine build(StateMachineContext<S, E> context, byte[] serialisedContext) {
+	protected MongoDbRepositoryStateMachine build(StateMachineContext<S, E> context, Object contextObj, byte[] serialisedContext) {
 		MongoDbRepositoryStateMachine mongodbRepositoryStateMachine = new MongoDbRepositoryStateMachine();
+		mongodbRepositoryStateMachine.setId(contextObj.toString());
 		mongodbRepositoryStateMachine.setMachineId(context.getId());
 		mongodbRepositoryStateMachine.setState(context.getState().toString());
 		mongodbRepositoryStateMachine.setStateMachineContext(serialisedContext);

--- a/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisRepositoryStateMachine.java
+++ b/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisRepositoryStateMachine.java
@@ -35,6 +35,14 @@ public class RedisRepositoryStateMachine extends RepositoryStateMachine {
 	private String state;
 	private byte[] stateMachineContext;
 
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	@Override
 	public String getMachineId() {
 		return machineId;

--- a/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisRepositoryStateMachinePersist.java
+++ b/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisRepositoryStateMachinePersist.java
@@ -60,8 +60,9 @@ public class RedisRepositoryStateMachinePersist<S, E> extends RepositoryStateMac
 	}
 
 	@Override
-	protected RedisRepositoryStateMachine build(StateMachineContext<S, E> context, byte[] serialisedContext) {
+	protected RedisRepositoryStateMachine build(StateMachineContext<S, E> context, Object contextObj, byte[] serialisedContext) {
 		RedisRepositoryStateMachine redisRepositoryStateMachine = new RedisRepositoryStateMachine();
+		redisRepositoryStateMachine.setId(contextObj.toString());
 		redisRepositoryStateMachine.setMachineId(context.getId());
 		redisRepositoryStateMachine.setState(context.getState().toString());
 		redisRepositoryStateMachine.setStateMachineContext(serialisedContext);

--- a/spring-statemachine-data/src/main/java/org/springframework/statemachine/data/RepositoryStateMachinePersist.java
+++ b/spring-statemachine-data/src/main/java/org/springframework/statemachine/data/RepositoryStateMachinePersist.java
@@ -59,7 +59,7 @@ public abstract class RepositoryStateMachinePersist<M extends RepositoryStateMac
 		if (log.isDebugEnabled()) {
 			log.debug("Persisting context " + context + " using contextObj " + contextObj);
 		}
-		M build = build(context, serialisationService.serialiseStateMachineContext(context));
+		M build = build(context, contextObj, serialisationService.serialiseStateMachineContext(context));
 		getRepository().save(build);
 	}
 
@@ -86,5 +86,5 @@ public abstract class RepositoryStateMachinePersist<M extends RepositoryStateMac
 	 * @param serialisedContext the serialised context
 	 * @return the repository state machine entity
 	 */
-	protected abstract M build(StateMachineContext<S, E> context, byte[] serialisedContext);
+	protected abstract M build(StateMachineContext<S, E> context, Object contextObj, byte[] serialisedContext);
 }


### PR DESCRIPTION
Fixes #494

I did not change the `JpaRepositoryStateMachine` although I think there should be a separate `@Id` field as well, which should be set to contextObj also.