### PR TITLE
Add support for completion transitions

### DIFF
--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/LinkedRegionsTests.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/LinkedRegionsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ public class LinkedRegionsTests extends AbstractBuildTests {
 		StateMachineTestPlan<String, String> plan =
 				StateMachineTestPlanBuilder.<String, String>builder()
 					.stateMachine(stateMachine)
-					.step().expectStateChanged(19).expectStates("S3").and()
+					.step().expectStateChanged(15).expectStates("S3").and()
 					.build();
 		plan.test();
 		assertThat(listener.statesEntered, not(hasItem(startsWith("JOIN"))));

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/listener/OrderedComposite.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/listener/OrderedComposite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ public class OrderedComposite<S> {
 	 *
 	 * @param item item
 	 */
-	public void add(S item) {
+	public synchronized void add(S item) {
 		if (item instanceof Ordered) {
 			if (!ordered.contains(item)) {
 				ordered.add(item);
@@ -89,7 +89,7 @@ public class OrderedComposite<S> {
 	 *
 	 * @param item item
 	 */
-	public void remove(S item) {
+	public synchronized void remove(S item) {
 		ordered.remove(item);
 		unordered.remove(item);
 		Collections.sort(ordered, comparator);
@@ -120,4 +120,8 @@ public class OrderedComposite<S> {
 		return result.iterator();
 	}
 
+	@Override
+	public String toString() {
+		return "OrderedComposite list=" + list.size() + " hash=" + hashCode();
+	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/JoinPseudoState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/JoinPseudoState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.state.PseudoStateContext.PseudoAction;
-import org.springframework.statemachine.support.StateMachineUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -112,30 +111,21 @@ public class JoinPseudoState<S, E> extends AbstractPseudoState<S, E> {
 			this.track = new ArrayList<State<S,E>>(joins);
 			for (State<S, E> tt : joins) {
 				final State<S, E> t = tt;
-				t.addStateListener(new StateListener<S, E>() {
+				t.addStateListener(new StateListenerAdapter<S, E>() {
 
 					@Override
-					public void onEntry(StateContext<S, E> context) {
-						if (context.getTransition() != null && StateMachineUtils
-								.isPseudoState(context.getTransition().getTarget(), PseudoStateKind.END)) {
-							if (!notified && track.size() > 0) {
-								track.remove(t);
-								if (track.size() == 0) {
-									notified = true;
-									notifyContext(new DefaultPseudoStateContext<S, E>(JoinPseudoState.this, PseudoAction.JOIN_COMPLETED));
-								}
-							}
-						}
-					}
-
-					@Override
-					public void onExit(StateContext<S, E> context) {
-						if (!notified && track.size() > 0) {
+					public void onComplete(StateContext<S, E> context) {
+						boolean trackSizeZero = false;
+						synchronized (track) {
 							track.remove(t);
 							if (track.size() == 0) {
-								notified = true;
-								notifyContext(new DefaultPseudoStateContext<S, E>(JoinPseudoState.this, PseudoAction.JOIN_COMPLETED));
+								trackSizeZero = true;
 							}
+						}
+						if (!notified && trackSizeZero) {
+							log.debug("Join complete");
+							notified = true;
+							notifyContext(new DefaultPseudoStateContext<S, E>(JoinPseudoState.this, PseudoAction.JOIN_COMPLETED));
 						}
 					}
 				});

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/ObjectState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/ObjectState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,6 @@ public class ObjectState<S, E> extends AbstractSimpleState<S, E> {
 
 	@Override
 	public void entry(StateContext<S, E> context) {
-		super.entry(context);
 		for (Action<S, E> action : getEntryActions()) {
 			try {
 				executeAction(action, context);
@@ -161,6 +160,7 @@ public class ObjectState<S, E> extends AbstractSimpleState<S, E> {
 				log.error("Action execution resulted error", e);
 			}
 		}
+		super.entry(context);
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/RegionState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/RegionState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/StateListener.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/StateListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,4 +40,11 @@ public interface StateListener<S, E> {
 	 * @param context the state context
 	 */
 	void onExit(StateContext<S, E> context);
+
+	/**
+	 * Called when {@link State} want to notify of its completion.
+	 *
+	 * @param context the state context
+	 */
+	void onComplete(StateContext<S, E> context);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/StateListenerAdapter.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/StateListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,40 +15,28 @@
  */
 package org.springframework.statemachine.state;
 
-import java.util.Iterator;
-
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.listener.AbstractCompositeListener;
 
 /**
- * Composite state listener.
+ * Adapter implementation of {@link StateListener} implementing all
+ * methods which extended implementation can override.
  *
  * @author Janne Valkealahti
  *
  * @param <S> the type of state
  * @param <E> the type of event
  */
-public class CompositeStateListener<S, E> extends AbstractCompositeListener<StateListener<S, E>>
-		implements StateListener<S, E> {
+public class StateListenerAdapter<S, E> implements StateListener<S, E> {
 
 	@Override
 	public void onEntry(StateContext<S, E> context) {
-		for (Iterator<StateListener<S, E>> iterator = getListeners().reverse(); iterator.hasNext();) {
-			iterator.next().onEntry(context);
-		}
 	}
 
 	@Override
 	public void onExit(StateContext<S, E> context) {
-		for (Iterator<StateListener<S, E>> iterator = getListeners().reverse(); iterator.hasNext();) {
-			iterator.next().onExit(context);
-		}
 	}
 
 	@Override
 	public void onComplete(StateContext<S, E> context) {
-		for (Iterator<StateListener<S, E>> iterator = getListeners().reverse(); iterator.hasNext();) {
-			iterator.next().onComplete(context);
-		}
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/LifecycleObjectSupport.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/LifecycleObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,7 +133,12 @@ public abstract class LifecycleObjectSupport implements InitializingBean, Dispos
 
 	@Override
 	public final void stop() {
-		this.lifecycleLock.lock();
+		if (!this.lifecycleLock.tryLock()) {
+			if (log.isDebugEnabled()) {
+				log.debug("already stopping " + this);
+			}
+			return;
+		}
 		try {
 			if (this.running) {
 				this.doStop();

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/StateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/StateMachineExecutor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.messaging.Message;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.access.StateMachineAccess;
+import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.transition.Transition;
 import org.springframework.statemachine.trigger.Trigger;
 
@@ -55,6 +56,14 @@ public interface StateMachineExecutor<S, E> {
 	 * @param message the message
 	 */
 	void queueDeferredEvent(Message<E> message);
+
+	/**
+	 * Execute and check all triggerless transitions.
+	 *
+	 * @param context the state context
+	 * @param state the state
+	 */
+	void executeTriggerlessTransitions(StateContext<S, E> context, State<S, E> state);
 
 	/**
 	 * Execute {@code StateMachineExecutor} logic.

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,6 +113,11 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 			}
 		}
 		return true;
+	}
+
+	@Override
+	public Guard<S, E> getGuard() {
+		return guard;
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.statemachine.transition;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.action.ActionListener;
+import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -63,6 +64,13 @@ public interface Transition<S, E> {
 	 * @return the target state
 	 */
 	State<S,E> getTarget();
+
+	/**
+	 * Gets the guard of this transition.
+	 *
+	 * @return the guard
+	 */
+	Guard<S, E> getGuard();
 
 	/**
 	 * Gets the transition actions.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,11 @@ public abstract class AbstractStateMachineTests {
 		READY,
 		FORK, JOIN,
 		TASKS, T1, T1E, T2, T2E, T3, T3E
+	}
+
+	public static enum TestStates4 {
+		READY, DONE,
+		TASKS, T1, T1E, T2, T2E
 	}
 
 	public static enum TestEvents2 {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/CompletionEventTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/CompletionEventTests.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.state;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.statemachine.AbstractStateMachineTests;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineSystemConstants;
+import org.springframework.statemachine.action.Action;
+import org.springframework.statemachine.config.EnableStateMachine;
+import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+
+public class CompletionEventTests extends AbstractStateMachineTests {
+
+	@Override
+	protected AnnotationConfigApplicationContext buildContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSimpleStateWithStateActionCompletes() throws Exception {
+		context.register(Config1.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		TestCountAction testAction2 = context.getBean("testAction2", TestCountAction.class);
+
+		machine.start();
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+
+		assertThat(testAction2.latch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(testAction2.count, is(1));
+		Thread.sleep(1000);
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSimpleStateWithStateActionCompletesThreading() throws Exception {
+		context.register(Config1.class, BaseConfig2.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		TestCountAction testAction2 = context.getBean("testAction2", TestCountAction.class);
+
+		machine.start();
+		Thread.sleep(1000);
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+
+		assertThat(testAction2.latch.await(2, TimeUnit.SECONDS), is(true));
+		assertThat(testAction2.count, is(1));
+		Thread.sleep(1000);
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSimpleStateWithoutStateActionCompletes() throws Exception {
+		context.register(Config2.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+
+		machine.start();
+		assertThat(machine.getState().getId(), is("S1"));
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	public void testSubmachineWithStateActionCompletes() throws Exception {
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSubmachineWithoutStateActionCompletes() throws Exception {
+		context.register(Config3.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+
+		machine.start();
+		assertThat(machine.getState().getId(), is("S1"));
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSubmachineWithoutStateActionCompletes2() throws Exception {
+		context.register(Config5.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+
+		machine.start();
+		assertThat(machine.getState().getId(), is("S1"));
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testSubmachineWithoutStateActionCompletesThreading() throws Exception {
+		context.register(Config3.class, BaseConfig2.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+
+		machine.start();
+		Thread.sleep(200);
+		assertThat(machine.getState().getId(), is("S1"));
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		Thread.sleep(200);
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	public void testRegionWithStateActionCompletes() throws Exception {
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testRegionWithoutStateActionCompletes() throws Exception {
+		context.register(Config4.class);
+		context.refresh();
+		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
+		StateMachine<String,String> machine =
+				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+
+		machine.start();
+		assertThat(machine.getState().getId(), is("S1"));
+
+		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		assertThat(machine.getState().getId(), is("S3"));
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config1 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.stateDo("S2", testAction2())
+					.state("S3");
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+
+		@Bean
+		public TestCountAction testAction2() {
+			return new TestCountAction() {
+				@Override
+				public void execute(StateContext<String, String> context) {
+					for (int i = 0; i < 10; i++) {
+						try {
+							Thread.sleep(100);
+						} catch (InterruptedException e) {
+						}
+					}
+					super.execute(context);
+				}
+			};
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config2 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2")
+					.state("S3");
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config3 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2")
+					.state("S3")
+					.and()
+					.withStates()
+						.parent("S2")
+						.initial("S21")
+						.state("S22")
+						.end("S23");
+
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S21")
+					.target("S22")
+					.and()
+				.withExternal()
+					.source("S22")
+					.target("S23")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config4 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2")
+					.state("S3")
+					.and()
+					.withStates()
+						.parent("S2")
+						.initial("S201")
+						.state("S202")
+						.end("S203")
+						.and()
+					.withStates()
+						.parent("S2")
+						.initial("S211")
+						.state("S212")
+						.end("S213");
+
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S201")
+					.target("S202")
+					.and()
+				.withExternal()
+					.source("S202")
+					.target("S203")
+					.and()
+				.withExternal()
+					.source("S211")
+					.target("S212")
+					.and()
+				.withExternal()
+					.source("S212")
+					.target("S213")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config5 extends StateMachineConfigurerAdapter<String, String> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<String, String> states) throws Exception {
+			states
+				.withStates()
+					.initial("S1")
+					.state("S2")
+					.state("S3")
+					.and()
+					.withStates()
+						.parent("S2")
+						.initial("S21")
+						.state("S22")
+						.end("S23")
+						.and()
+						.withStates()
+							.parent("S22")
+							.initial("S221")
+							.state("S222")
+							.end("S223");
+
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<String, String> transitions) throws Exception {
+			transitions
+				.withExternal()
+					.source("S1")
+					.target("S2")
+					.event("E1")
+					.and()
+				.withExternal()
+					.source("S21")
+					.target("S22")
+					.and()
+				.withExternal()
+					.source("S22")
+					.target("S23")
+					.and()
+				.withExternal()
+					.source("S221")
+					.target("S222")
+					.and()
+				.withExternal()
+					.source("S222")
+					.target("S223")
+					.and()
+				.withExternal()
+					.source("S2")
+					.target("S3");
+		}
+	}
+
+	private static class TestCountAction implements Action<String, String> {
+
+		int count = 0;
+		StateContext<String, String> context;
+		CountDownLatch latch = new CountDownLatch(1);
+
+		public TestCountAction() {
+			count = 0;
+		}
+
+		@Override
+		public void execute(StateContext<String, String> context) {
+			this.context = context;
+			count++;
+			latch.countDown();
+		}
+
+	}
+
+}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JoinStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JoinStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.access.StateMachineAccessor;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.action.ActionListener;
+import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.listener.StateMachineListener;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.EnumState;
@@ -116,6 +117,11 @@ public class StateContextExpressionMethodsTests {
 		@Override
 		public State<SpelStates, SpelEvents> getTarget() {
 			return new EnumState<SpelStates, SpelEvents>(SpelStates.S2);
+		}
+
+		@Override
+		public Guard<SpelStates, SpelEvents> getGuard() {
+			return null;
 		}
 
 		@Override

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,7 +348,7 @@ public class TransitionTests extends AbstractStateMachineTests {
 		listener.reset(3);
 		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).setHeader("testHeader", "testValue").build());
 		assertThat(testAction1.latch.await(2, TimeUnit.SECONDS), is(true));
-		assertThat(listener.s20Latch.getCount(), is(1L));
+		assertThat(listener.s20Latch.await(2, TimeUnit.SECONDS), is(true));
 
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
@@ -832,13 +832,11 @@ public class TransitionTests extends AbstractStateMachineTests {
 
 		@Override
 		public void execute(StateContext<TestStates, TestEvents> context) {
-			log.info("XXX11");
 			try {
 				Thread.sleep(500);
 			} catch (InterruptedException e) {
 			}
 			testHeader = context.getMessageHeaders().get("testHeader", String.class);
-			log.info("XXX12");
 			latch.countDown();
 		}
 

--- a/spring-statemachine-samples/tasks/src/test/resources/logback.xml
+++ b/spring-statemachine-samples/tasks/src/test/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss} %t %m%n</pattern>
+			<charset>utf8</charset>
+		</encoder>
+	</appender>
+
+	<root level="WARN">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+	<logger name="org.springframework.statemachine" level="DEBUG"/>
+
+</configuration>


### PR DESCRIPTION
- Currently into as internal new feature, add state
  completed concecept and use it in various places.
- Main focus for this commit is to add support using
  anonymous transitions with state do actions which
  requires proper completion schematics.
- Internal functionality here will probably expose to
  user level in future releases using various other
  concepts.
- Fixes #466