### PR TITLE
Add getter for state actions

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/AbstractState.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/AbstractState.java
@@ -235,6 +235,11 @@ public abstract class AbstractState<S, E> extends LifecycleObjectSupport impleme
 	}
 
 	@Override
+	public Collection<? extends Action<S, E>> getStateActions() {
+		return stateActions;
+	}
+
+	@Override
 	public Collection<? extends Action<S, E>> getExitActions() {
 		return exitActions;
 	}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/State.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/state/State.java
@@ -109,6 +109,13 @@ public interface State<S, E> {
 	Collection<? extends Action<S, E>> getEntryActions();
 
 	/**
+	 * Gets {@link Action}s executed once in this state.
+	 *
+	 * @return the state actions
+	 */
+	Collection<? extends Action<S, E>> getStateActions();
+
+	/**
 	 * Gets {@link Action}s executed exiting from this state.
 	 *
 	 * @return the state exit actions

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
@@ -159,6 +159,23 @@ public abstract class AbstractStateMachineTests {
 
 	}
 
+	public static class TestStateAction extends AbstractTestAction {
+
+		public TestStateAction() {
+			super();
+		}
+
+		public TestStateAction(String message) {
+			super(message);
+		}
+
+		@Override
+		public String toString() {
+			return "TestStateAction [message=" + message + "]";
+		}
+
+	}
+
 	public static class TestAction extends AbstractTestAction {
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurerTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.springframework.statemachine.AbstractStateMachineTests.TestEntryAction;
 import org.springframework.statemachine.AbstractStateMachineTests.TestEvents;
 import org.springframework.statemachine.AbstractStateMachineTests.TestExitAction;
+import org.springframework.statemachine.AbstractStateMachineTests.TestStateAction;
 import org.springframework.statemachine.AbstractStateMachineTests.TestStates;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.builders.StateMachineStateBuilder;
@@ -97,6 +98,7 @@ public class DefaultStateConfigurerTests {
 
 		assertThat(builder.data.iterator().next().getState(), is(TestStates.S1));
 		assertThat(builder.data.iterator().next().getEntryActions(), nullValue());
+		assertThat(builder.data.iterator().next().getStateActions(), nullValue());
 		assertThat(builder.data.iterator().next().getExitActions(), notNullValue());
 	}
 
@@ -113,7 +115,25 @@ public class DefaultStateConfigurerTests {
 
 		assertThat(builder.data.iterator().next().getState(), is(TestStates.S2));
 		assertThat(builder.data.iterator().next().getExitActions(), nullValue());
+		assertThat(builder.data.iterator().next().getStateActions(), nullValue());
 		assertThat(builder.data.iterator().next().getEntryActions(), notNullValue());
+	}
+
+	@Test
+	public void testStateActions() throws Exception {
+		Collection<Action<TestStates, TestEvents>> stateActions = Arrays.asList(testStateAction());
+
+		DefaultStateConfigurer<TestStates, TestEvents> configurer = new DefaultStateConfigurer<TestStates, TestEvents>();
+		TestStateMachineStateBuilder builder = new TestStateMachineStateBuilder();
+		configurer.state(TestStates.S2, stateActions);
+		configurer.configure(builder);
+		assertThat(builder.data, notNullValue());
+		assertThat(builder.data.size(), is(1));
+
+		assertThat(builder.data.iterator().next().getState(), is(TestStates.S2));
+		assertThat(builder.data.iterator().next().getExitActions(), nullValue());
+		assertThat(builder.data.iterator().next().getStateActions(), notNullValue());
+		assertThat(builder.data.iterator().next().getEntryActions(), nullValue());
 	}
 
 	@Test
@@ -169,4 +189,7 @@ public class DefaultStateConfigurerTests {
 		return new TestExitAction();
 	}
 
+	private Action<TestStates, TestEvents> testStateAction() {
+		return new TestStateAction();
+	}
 }


### PR DESCRIPTION
State has getters for entry and exit actions but no getter for state actions.

 - Add State::getStateActions() in State
 - Implement in AbstractState
 - Update tests

https://github.com/spring-projects/spring-statemachine/issues/502