### PR TITLE
Add getters on some fields in TimeTrigger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 		eclipseEmfEcoreVersion = '2.11.1-v20150805-0538'
 		eclipseUml2UmlVersion = '5.0.0-v20140602-0749'
 		curatorVersion = '2.11.1'
+		pojoBuilderVersion = '4.2.0'
 	}
 	repositories {
 		maven { url 'http://repo.springsource.org/libs-release'}
@@ -100,6 +101,7 @@ configure(allprojects) {
 			dependency "org.eclipse.emf:org.eclipse.emf.common:$eclipseEmfCommonVersion"
 			dependency "org.apache.curator:curator-recipes:$curatorVersion"
 			dependency "org.apache.curator:curator-test:$curatorVersion"
+			dependency "net.karneim:pojobuilder:$pojoBuilderVersion"
 		}
 	}
 
@@ -110,6 +112,11 @@ configure(allprojects) {
 	test {
 		exclude '**/*IntegrationTests.*'
 	}
+
+	configurations {
+		codeGeneration
+	}
+
 }
 
 configure(subprojects) { subproject ->
@@ -162,12 +169,19 @@ configure(subprojects) { subproject ->
 			plusConfigurations += [ configurations.optional ]
 		}
 	}
+
+	compileJava.classpath += configurations.codeGeneration
+	compileTestJava.classpath += configurations.codeGeneration
+	// compileJava.options.compilerArgs += ['-s', 'build/generated/java']
 }
+
 
 project('spring-statemachine-core') {
 	description = "Spring State Machine Core"
     
 	dependencies {
+		codeGeneration "net.karneim:pojobuilder"
+		compileOnly "net.karneim:pojobuilder:$pojoBuilderVersion:annotations"
 		compile "org.springframework:spring-tx"
 		compile "org.springframework:spring-messaging"
 		optional "org.springframework.security:spring-security-core"

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineContext.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineContext.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.karneim.pojobuilder.GeneratePojoBuilder;
 import org.springframework.statemachine.ExtendedState;
 import org.springframework.statemachine.StateMachineContext;
 
@@ -122,6 +123,7 @@ public class DefaultStateMachineContext<S, E> implements StateMachineContext<S, 
 	 * @param historyStates the history state mappings
 	 * @param id the machine id
 	 */
+	@GeneratePojoBuilder(withSetterNamePattern = "*", withFactoryMethod = "create")
 	public DefaultStateMachineContext(List<StateMachineContext<S, E>> childs, S state, E event,
 			Map<String, Object> eventHeaders, ExtendedState extendedState, Map<S, S> historyStates, String id) {
 		this.childs = childs;


### PR DESCRIPTION
Add getters on some fields in TimeTrigger.

As you add some getter on Transition recently, I would like to add some getters on TimeTrigger.
In my project, we generate automatically some graph image via PlantUML from the configuration of the state machine and we want to see on these information (timeout / count).