### PR TITLE
Fix 1.2.x build for jdk7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,11 @@ configure(allprojects) {
 	apply plugin: 'idea'
 	apply plugin: 'propdeps'
 
+	configurations {
+		sniffer
+		javaApiSignature
+	}
+
 	if (System.env.TRAVIS == 'true') {
 		tasks.withType(GroovyCompile) {
 			groovyOptions.fork = false
@@ -67,6 +72,46 @@ configure(allprojects) {
 	test {
 		exclude '**/*IntegrationTests.*'
 	}
+
+	dependencies {
+		sniffer("org.codehaus.mojo:animal-sniffer-ant-tasks:${snifferVersion}")
+		javaApiSignature("org.codehaus.mojo.signature:java17:1.0@signature")  // API level from JDK 7
+	}
+
+	task copyJavaApiSignature(type: Copy) {
+		ext.to = file("$buildDir/javaApiSignature/")
+		description "Copy the resolved Animal Sniffer signature dependency artifact to a known location and name"
+		from configurations.javaApiSignature
+		into to
+		rename '.*signature', 'javaApi.signature'
+	}
+
+	task sniff {
+		group = "Verification"
+		description = "Checks the Java API signatures"
+
+		dependsOn compileJava
+		dependsOn copyJavaApiSignature
+
+		inputs.dir sourceSets.main.output.classesDir
+		inputs.dir copyJavaApiSignature.to
+
+		doLast {
+			ant.taskdef(
+				name: 'animalSniffer',
+				classname: 'org.codehaus.mojo.animal_sniffer.ant.CheckSignatureTask',
+				classpath: configurations.sniffer.asPath
+			)
+
+			ant.animalSniffer(
+					signature: "$buildDir/javaApiSignature/javaApi.signature",
+					classpath: sourceSets.main.compileClasspath.asPath) {
+				path(path: sourceSets.main.output.classesDir)
+			}
+		}
+	}
+
+	build.dependsOn sniff
 }
 
 configure(subprojects) { subproject ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,4 @@ hamcrestVersion=1.3
 springShellVersion=1.1.0.RELEASE
 jackson2Version=2.8.3
 springDataJpaVersion=1.10.3.RELEASE
+snifferVersion=1.16

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/DefaultStateMachineExecutor.java
@@ -133,7 +133,7 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 		this.transitionComparator = new TransitionComparator<S, E>(transitionConflictPolicy);
 		this.transitionConflictPolicy = transitionConflictPolicy;
 		// anonymous transitions are fixed, sort those now
-		this.triggerlessTransitions.sort(transitionComparator);
+		Collections.sort(this.triggerlessTransitions, transitionComparator);
 		registerTriggerListener();
 	}
 
@@ -453,7 +453,7 @@ public class DefaultStateMachineExecutor<S, E> extends LifecycleObjectSupport im
 			}
 
 			// go through candidates and transit max one, sort before handling
-			trans.sort(transitionComparator);
+			Collections.sort(trans, transitionComparator);
 			handleTriggerTrans(trans, queuedMessage);
 		}
 


### PR DESCRIPTION
- Add proper build sniffer config to catch
  jdk7 compat. This is pretty much one used
  in a framework build itself.
- Fix jdk7 usage in DefaultStateMachineExecutor.
- Resolves #561