### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
 	repositories {
-		maven { url 'http://repo.springsource.org/libs-release'}
-		maven { url 'http://repo.springsource.org/plugins-release' }
+		maven { url 'https://repo.springsource.org/libs-release'}
+		maven { url 'https://repo.springsource.org/plugins-release' }
 	}
 	dependencies {
 		classpath("org.springframework.build.gradle:propdeps-plugin:0.0.7")
@@ -45,8 +45,8 @@ configure(allprojects) {
 
 	repositories {
 		mavenCentral()
-		maven { url "http://repo.springsource.org/libs-release" }
-		maven { url "http://repo.springsource.org/libs-milestone" }
+		maven { url "https://repo.springsource.org/libs-release" }
+		maven { url "https://repo.springsource.org/libs-milestone" }
 	}
 
 	task integrationTest(type: Test) {
@@ -390,7 +390,7 @@ configure(rootProject) {
 		options.author = true
 		options.header = rootProject.description
 		options.links(
-			'http://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
+			'https://docs.jboss.org/jbossas/javadoc/4.0.5/connector'
 		)
 
 		// disable javadocs for samples

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
             url = 'https://github.com/spring-projects/spring-statemachine'
             organization {
                 name = 'SpringSource'
-                url = 'http://spring.io/spring-statemachine'
+                url = 'https://spring.io/spring-statemachine'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://docs.jboss.org/jbossas/javadoc/4.0.5/connector with 1 occurrences migrated to:  
  https://docs.jboss.org/jbossas/javadoc/4.0.5/connector ([https](https://docs.jboss.org/jbossas/javadoc/4.0.5/connector) result 301).
* http://repo.springsource.org/libs-milestone with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release with 2 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/plugins-release with 1 occurrences migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://spring.io/spring-statemachine with 1 occurrences migrated to:  
  https://spring.io/spring-statemachine ([https](https://spring.io/spring-statemachine) result 302).