### PR TITLE
Fix pseudostate parent with uml machine references

### DIFF
--- a/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
+++ b/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
@@ -239,6 +239,16 @@ public class UmlModelParser {
 				String regionId = null;
 				if (state.getContainer().getOwner() instanceof State) {
 					parent = ((State)state.getContainer().getOwner()).getName();
+				} else if (state.getContainer().getOwner() instanceof StateMachine) {
+					// in case of a submachine ref, owner should be StateMachine instead
+					// of State so try to find from owning submachines states a matching one with a
+					// same name.
+					StateMachine owningMachine = (StateMachine)state.getContainer().getOwner();
+					parent = owningMachine.getSubmachineStates().stream()
+							.filter(m -> owningMachine == m.getSubmachine())
+							.map(s -> s.getName())
+							.findFirst()
+							.orElse(null);
 				}
 				if (state.getOwner() instanceof Region) {
 					regionId = ((Region)state.getOwner()).getName();

--- a/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
+++ b/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
@@ -1082,6 +1082,46 @@ public class UmlStateMachineModelFactoryTests extends AbstractUmlTests {
 		assertThat(choiceToS6.latch.await(1, TimeUnit.SECONDS), is(true));
 	}
 
+	@Test
+	public void testPseudostateInSubmachineHaveCorrectParent() {
+		context.refresh();
+		Resource model = new ClassPathResource("org/springframework/statemachine/uml/pseudostate-in-submachine.uml");
+		UmlStateMachineModelFactory builder = new UmlStateMachineModelFactory(model);
+		assertThat(model.exists(), is(true));
+		StateMachineModel<String, String> stateMachineModel = builder.build();
+		assertThat(stateMachineModel, notNullValue());
+		Collection<StateData<String, String>> stateDatas = stateMachineModel.getStatesData().getStateData();
+
+		assertThat(stateDatas.size(), is(4));
+
+		StateData<String, String> choiceStateData = stateDatas.stream()
+				.filter(sd -> "CHOICE".equals(sd.getState()))
+				.findFirst()
+				.get();
+		assertThat(choiceStateData, notNullValue());
+		assertThat(choiceStateData.getParent(), is("S1"));
+	}
+
+	@Test
+	public void testPseudostateInSubmachinerefHaveCorrectParent() {
+		context.refresh();
+		Resource model = new ClassPathResource("org/springframework/statemachine/uml/pseudostate-in-submachineref.uml");
+		UmlStateMachineModelFactory builder = new UmlStateMachineModelFactory(model);
+		assertThat(model.exists(), is(true));
+		StateMachineModel<String, String> stateMachineModel = builder.build();
+		assertThat(stateMachineModel, notNullValue());
+		Collection<StateData<String, String>> stateDatas = stateMachineModel.getStatesData().getStateData();
+
+		assertThat(stateDatas.size(), is(4));
+
+		StateData<String, String> choiceStateData = stateDatas.stream()
+				.filter(sd -> "CHOICE".equals(sd.getState()))
+				.findFirst()
+				.get();
+		assertThat(choiceStateData, notNullValue());
+		assertThat(choiceStateData.getParent(), is("S1"));
+	}
+
 	@Configuration
 	@EnableStateMachine
 	public static class Config2 extends StateMachineConfigurerAdapter<String, String> {

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachine.di
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachine.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachine.notation
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachine.notation
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<notation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_IpwKwGHZEemXZLuVVkpDrQ" type="PapyrusUMLStateMachineDiagram" name="State Machine Diagram" measurementUnit="Pixel">
+  <children xmi:type="notation:Shape" xmi:id="_IpwKwWHZEemXZLuVVkpDrQ" type="StateMachine_Shape">
+    <children xmi:type="notation:DecorationNode" xmi:id="_IpwKwmHZEemXZLuVVkpDrQ" type="StateMachine_NameLabel">
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpwKw2HZEemXZLuVVkpDrQ" width="791" height="20"/>
+    </children>
+    <children xmi:type="notation:BasicCompartment" xmi:id="_IpwKxGHZEemXZLuVVkpDrQ" type="StateMachine_RegionCompartment">
+      <children xmi:type="notation:Shape" xmi:id="_IpwKxWHZEemXZLuVVkpDrQ" type="Region_Shape">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_IpwKxmHZEemXZLuVVkpDrQ" source="RegionAnnotationKey">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_IpwKx2HZEemXZLuVVkpDrQ" key="RegionZoneKey" value=""/>
+        </eAnnotations>
+        <children xmi:type="notation:BasicCompartment" xmi:id="_IpwKyGHZEemXZLuVVkpDrQ" type="Region_SubvertexCompartment">
+          <children xmi:type="notation:Shape" xmi:id="_jlc8MGHZEemXZLuVVkpDrQ" type="State_Shape">
+            <children xmi:type="notation:DecorationNode" xmi:id="_jlc8MmHZEemXZLuVVkpDrQ" type="State_NameLabel">
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_j-5-AGHZEemXZLuVVkpDrQ" width="461" height="20"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_jldjQGHZEemXZLuVVkpDrQ" type="State_FloatingNameLabel">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_jldjQWHZEemXZLuVVkpDrQ" x="40"/>
+            </children>
+            <children xmi:type="notation:BasicCompartment" xmi:id="_jldjQmHZEemXZLuVVkpDrQ" type="State_RegionCompartment">
+              <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oG0OkGHZEemXZLuVVkpDrQ" source="PapyrusCSSForceValue">
+                <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oG01oGHZEemXZLuVVkpDrQ" key="visible" value="true"/>
+              </eAnnotations>
+              <children xmi:type="notation:Shape" xmi:id="_oG348GHZEemXZLuVVkpDrQ" type="Region_Shape">
+                <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_oG4gAGHZEemXZLuVVkpDrQ" source="RegionAnnotationKey">
+                  <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_oG4gAWHZEemXZLuVVkpDrQ" key="RegionZoneKey" value=""/>
+                </eAnnotations>
+                <children xmi:type="notation:BasicCompartment" xmi:id="_oG348mHZEemXZLuVVkpDrQ" type="Region_SubvertexCompartment">
+                  <children xmi:type="notation:Shape" xmi:id="_oG9_kGHZEemXZLuVVkpDrQ" type="State_Shape">
+                    <children xmi:type="notation:DecorationNode" xmi:id="_oG9_kmHZEemXZLuVVkpDrQ" type="State_NameLabel"/>
+                    <children xmi:type="notation:DecorationNode" xmi:id="_oG-moGHZEemXZLuVVkpDrQ" type="State_FloatingNameLabel">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_oG-moWHZEemXZLuVVkpDrQ" x="40"/>
+                    </children>
+                    <children xmi:type="notation:BasicCompartment" xmi:id="_oG-momHZEemXZLuVVkpDrQ" type="State_RegionCompartment">
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oG-mo2HZEemXZLuVVkpDrQ"/>
+                    </children>
+                    <element xmi:type="uml:State" href="pseudostate-in-submachine.uml#_oG7jUGHZEemXZLuVVkpDrQ"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oG9_kWHZEemXZLuVVkpDrQ" x="119" y="29"/>
+                  </children>
+                  <children xmi:type="notation:Shape" xmi:id="_rBi6UGHZEemXZLuVVkpDrQ" type="Pseudostate_ChoiceShape">
+                    <children xmi:type="notation:DecorationNode" xmi:id="_rBi6UmHZEemXZLuVVkpDrQ" type="Pseudostate_ChoiceFloatingNameLabel">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_rBi6U2HZEemXZLuVVkpDrQ" y="-20"/>
+                    </children>
+                    <children xmi:type="notation:DecorationNode" xmi:id="_rBjhYGHZEemXZLuVVkpDrQ" type="Pseudostate_ChoiceStereotypeLabel">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_rBjhYWHZEemXZLuVVkpDrQ" x="25" y="-10"/>
+                    </children>
+                    <element xmi:type="uml:Pseudostate" href="pseudostate-in-submachine.uml#_rBTCsGHZEemXZLuVVkpDrQ"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rBi6UWHZEemXZLuVVkpDrQ" x="199" y="49"/>
+                  </children>
+                  <children xmi:type="notation:Shape" xmi:id="_wxgGwGHZEemXZLuVVkpDrQ" type="State_Shape">
+                    <children xmi:type="notation:DecorationNode" xmi:id="_wxgGwmHZEemXZLuVVkpDrQ" type="State_NameLabel"/>
+                    <children xmi:type="notation:DecorationNode" xmi:id="_wxgt0GHZEemXZLuVVkpDrQ" type="State_FloatingNameLabel">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_wxgt0WHZEemXZLuVVkpDrQ" x="40"/>
+                    </children>
+                    <children xmi:type="notation:BasicCompartment" xmi:id="_wxgt0mHZEemXZLuVVkpDrQ" type="State_RegionCompartment">
+                      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wxgt02HZEemXZLuVVkpDrQ"/>
+                    </children>
+                    <element xmi:type="uml:State" href="pseudostate-in-submachine.uml#_wxTScGHZEemXZLuVVkpDrQ"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_wxgGwWHZEemXZLuVVkpDrQ" x="299" y="29"/>
+                  </children>
+                  <children xmi:type="notation:Shape" xmi:id="_4HAUsGHZEemXZLuVVkpDrQ" type="Pseudostate_InitialShape">
+                    <children xmi:type="notation:DecorationNode" xmi:id="_4HA7wWHZEemXZLuVVkpDrQ" type="Pseudostate_InitialFloatingNameLabel">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_4HA7wmHZEemXZLuVVkpDrQ" x="25" y="3"/>
+                    </children>
+                    <children xmi:type="notation:DecorationNode" xmi:id="_4HA7w2HZEemXZLuVVkpDrQ" type="Pseudostate_InitialStereotypeLabel">
+                      <layoutConstraint xmi:type="notation:Location" xmi:id="_4HA7xGHZEemXZLuVVkpDrQ" x="25" y="-10"/>
+                    </children>
+                    <element xmi:type="uml:Pseudostate" href="pseudostate-in-submachine.uml#_4Gun4GHZEemXZLuVVkpDrQ"/>
+                    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4HA7wGHZEemXZLuVVkpDrQ" x="32" y="44"/>
+                  </children>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oG3482HZEemXZLuVVkpDrQ"/>
+                </children>
+                <element xmi:type="uml:Region" href="pseudostate-in-submachine.uml#_oG1csGHZEemXZLuVVkpDrQ"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oG348WHZEemXZLuVVkpDrQ" width="461" height="257"/>
+              </children>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jldjQ2HZEemXZLuVVkpDrQ" y="20" width="461" height="257"/>
+            </children>
+            <element xmi:type="uml:State" href="pseudostate-in-submachine.uml#_jlVncGHZEemXZLuVVkpDrQ"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_jlc8MWHZEemXZLuVVkpDrQ" x="129" y="61" width="461" height="277"/>
+          </children>
+          <children xmi:type="notation:Shape" xmi:id="_3LAmgGHZEemXZLuVVkpDrQ" type="Pseudostate_InitialShape">
+            <children xmi:type="notation:DecorationNode" xmi:id="_3LBNkGHZEemXZLuVVkpDrQ" type="Pseudostate_InitialFloatingNameLabel">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3LBNkWHZEemXZLuVVkpDrQ" x="25" y="3"/>
+            </children>
+            <children xmi:type="notation:DecorationNode" xmi:id="_3LBNkmHZEemXZLuVVkpDrQ" type="Pseudostate_InitialStereotypeLabel">
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_3LBNk2HZEemXZLuVVkpDrQ" x="25" y="-10"/>
+            </children>
+            <element xmi:type="uml:Pseudostate" href="pseudostate-in-submachine.uml#_3K1nYGHZEemXZLuVVkpDrQ"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3LAmgWHZEemXZLuVVkpDrQ" x="19" y="130"/>
+          </children>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpwKyWHZEemXZLuVVkpDrQ"/>
+        </children>
+        <element xmi:type="uml:Region" href="pseudostate-in-submachine.uml#_IpsgYGHZEemXZLuVVkpDrQ"/>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpwKymHZEemXZLuVVkpDrQ" width="791" height="471"/>
+      </children>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpwKy2HZEemXZLuVVkpDrQ" y="20" width="791" height="471"/>
+    </children>
+    <element xmi:type="uml:StateMachine" href="pseudostate-in-submachine.uml#_IpRpoGHZEemXZLuVVkpDrQ"/>
+    <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IpwKzGHZEemXZLuVVkpDrQ" x="30" y="30" width="791" height="491"/>
+  </children>
+  <styles xmi:type="notation:StringValueStyle" xmi:id="_IpwKzWHZEemXZLuVVkpDrQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
+  <styles xmi:type="notation:DiagramStyle" xmi:id="_IpwKzmHZEemXZLuVVkpDrQ"/>
+  <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_IpwKz2HZEemXZLuVVkpDrQ" diagramKindId="org.eclipse.papyrus.uml.diagram.stateMachine">
+    <owner xmi:type="uml:Model" href="pseudostate-in-submachine.uml#_Iosa0GHZEemXZLuVVkpDrQ"/>
+  </styles>
+  <element xmi:type="uml:StateMachine" href="pseudostate-in-submachine.uml#_IpRpoGHZEemXZLuVVkpDrQ"/>
+  <edges xmi:type="notation:Connector" xmi:id="_6DqOoGHZEemXZLuVVkpDrQ" type="Transition_Edge" source="_3LAmgGHZEemXZLuVVkpDrQ" target="_jlc8MGHZEemXZLuVVkpDrQ">
+    <children xmi:type="notation:DecorationNode" xmi:id="_6Dq1sGHZEemXZLuVVkpDrQ" type="Transition_NameLabel">
+      <styles xmi:type="notation:BooleanValueStyle" xmi:id="_63JhEGHZEemXZLuVVkpDrQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dq1sWHZEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_6Dq1smHZEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+      <styles xmi:type="notation:BooleanValueStyle" xmi:id="_63W8cGHZEemXZLuVVkpDrQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dq1s2HZEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_6Dq1tGHZEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+      <styles xmi:type="notation:BooleanValueStyle" xmi:id="_63jwwGHZEemXZLuVVkpDrQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_6Dq1tWHZEemXZLuVVkpDrQ" y="59"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_6DqOoWHZEemXZLuVVkpDrQ"/>
+    <element xmi:type="uml:Transition" href="pseudostate-in-submachine.uml#_6BUsUGHZEemXZLuVVkpDrQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6DqOomHZEemXZLuVVkpDrQ" points="[60, 142, -643984, -643984]$[160, 140, -643984, -643984]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6EJ94GHZEemXZLuVVkpDrQ" id="(0.9,0.5)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6EJ94WHZEemXZLuVVkpDrQ" id="(0.0,0.2490974729241877)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_-5WLMGHZEemXZLuVVkpDrQ" type="Transition_Edge" source="_4HAUsGHZEemXZLuVVkpDrQ" target="_oG9_kGHZEemXZLuVVkpDrQ">
+    <children xmi:type="notation:DecorationNode" xmi:id="_-5WLM2HZEemXZLuVVkpDrQ" type="Transition_NameLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_-5WLNGHZEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_-5WLNWHZEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_-5WLNmHZEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_-5WLN2HZEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_-5WLOGHZEemXZLuVVkpDrQ" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_-5WLMWHZEemXZLuVVkpDrQ"/>
+    <element xmi:type="uml:Transition" href="pseudostate-in-submachine.uml#_-5HhsGHZEemXZLuVVkpDrQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_-5WLMmHZEemXZLuVVkpDrQ" points="[210, 180, -643984, -643984]$[280, 180, -643984, -643984]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-5yQEGHZEemXZLuVVkpDrQ" id="(0.875,0.25)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-5yQEWHZEemXZLuVVkpDrQ" id="(0.0,0.45454545454545453)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="__vfwEGHZEemXZLuVVkpDrQ" type="Transition_Edge" source="_oG9_kGHZEemXZLuVVkpDrQ" target="_rBi6UGHZEemXZLuVVkpDrQ">
+    <children xmi:type="notation:DecorationNode" xmi:id="__vfwE2HZEemXZLuVVkpDrQ" type="Transition_NameLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="__vfwFGHZEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="__vgXIGHZEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="__vgXIWHZEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="__vgXImHZEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="__vgXI2HZEemXZLuVVkpDrQ" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="__vfwEWHZEemXZLuVVkpDrQ"/>
+    <element xmi:type="uml:Transition" href="pseudostate-in-submachine.uml#__vOqUGHZEemXZLuVVkpDrQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="__vfwEmHZEemXZLuVVkpDrQ" points="[320, 194, -643984, -643984]$[360, 190, -643984, -643984]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wAtcGHZEemXZLuVVkpDrQ" id="(1.0,0.7727272727272727)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="__wBUgGHZEemXZLuVVkpDrQ" id="(0.0,0.5)"/>
+  </edges>
+  <edges xmi:type="notation:Connector" xmi:id="_AmOjwGHaEemXZLuVVkpDrQ" type="Transition_Edge" source="_rBi6UGHZEemXZLuVVkpDrQ" target="_wxgGwGHZEemXZLuVVkpDrQ">
+    <children xmi:type="notation:DecorationNode" xmi:id="_AmOjw2HaEemXZLuVVkpDrQ" type="Transition_NameLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_AmOjxGHaEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_AmOjxWHaEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_AmOjxmHaEemXZLuVVkpDrQ"/>
+    </children>
+    <children xmi:type="notation:DecorationNode" xmi:id="_AmOjx2HaEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+      <layoutConstraint xmi:type="notation:Location" xmi:id="_AmOjyGHaEemXZLuVVkpDrQ" y="60"/>
+    </children>
+    <styles xmi:type="notation:FontStyle" xmi:id="_AmOjwWHaEemXZLuVVkpDrQ"/>
+    <element xmi:type="uml:Transition" href="pseudostate-in-submachine.uml#_Al7BwGHaEemXZLuVVkpDrQ"/>
+    <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AmOjwmHaEemXZLuVVkpDrQ" points="[400, 196, -643984, -643984]$[460, 180, -643984, -643984]"/>
+    <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AmuTAGHaEemXZLuVVkpDrQ" id="(0.6666666666666666,0.8333333333333343)"/>
+    <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AmuTAWHaEemXZLuVVkpDrQ" id="(0.0,0.45454545454545453)"/>
+  </edges>
+</notation:Diagram>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachine.uml
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachine.uml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_Iosa0GHZEemXZLuVVkpDrQ" name="pseudostate-in-submachine">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_IyBV8GHZEemXZLuVVkpDrQ">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_IpRpoGHZEemXZLuVVkpDrQ" name="StateMachine">
+    <region xmi:type="uml:Region" xmi:id="_IpsgYGHZEemXZLuVVkpDrQ" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_6BUsUGHZEemXZLuVVkpDrQ" source="_3K1nYGHZEemXZLuVVkpDrQ" target="_jlVncGHZEemXZLuVVkpDrQ"/>
+      <subvertex xmi:type="uml:State" xmi:id="_jlVncGHZEemXZLuVVkpDrQ" name="S1">
+        <region xmi:type="uml:Region" xmi:id="_oG1csGHZEemXZLuVVkpDrQ" name="Region1">
+          <transition xmi:type="uml:Transition" xmi:id="_-5HhsGHZEemXZLuVVkpDrQ" source="_4Gun4GHZEemXZLuVVkpDrQ" target="_oG7jUGHZEemXZLuVVkpDrQ"/>
+          <transition xmi:type="uml:Transition" xmi:id="__vOqUGHZEemXZLuVVkpDrQ" source="_oG7jUGHZEemXZLuVVkpDrQ" target="_rBTCsGHZEemXZLuVVkpDrQ"/>
+          <transition xmi:type="uml:Transition" xmi:id="_Al7BwGHaEemXZLuVVkpDrQ" source="_rBTCsGHZEemXZLuVVkpDrQ" target="_wxTScGHZEemXZLuVVkpDrQ"/>
+          <subvertex xmi:type="uml:State" xmi:id="_oG7jUGHZEemXZLuVVkpDrQ" name="S11"/>
+          <subvertex xmi:type="uml:Pseudostate" xmi:id="_rBTCsGHZEemXZLuVVkpDrQ" name="CHOICE" kind="choice"/>
+          <subvertex xmi:type="uml:State" xmi:id="_wxTScGHZEemXZLuVVkpDrQ" name="S12"/>
+          <subvertex xmi:type="uml:Pseudostate" xmi:id="_4Gun4GHZEemXZLuVVkpDrQ" name=""/>
+        </region>
+      </subvertex>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_3K1nYGHZEemXZLuVVkpDrQ" name=""/>
+    </region>
+  </packagedElement>
+</uml:Model>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachineref.di
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachineref.di
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<architecture:ArchitectureDescription xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:architecture="http://www.eclipse.org/papyrus/infra/core/architecture" contextId="org.eclipse.papyrus.infra.services.edit.TypeContext"/>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachineref.notation
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachineref.notation
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/papyrus/infra/gmfdiag/style" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+  <notation:Diagram xmi:id="_yHzZEGHeEemXZLuVVkpDrQ" type="PapyrusUMLStateMachineDiagram" name="StateMachine Diagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_yHzZEWHeEemXZLuVVkpDrQ" type="StateMachine_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_yHzZEmHeEemXZLuVVkpDrQ" type="StateMachine_NameLabel">
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yHzZE2HeEemXZLuVVkpDrQ" width="700" height="20"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_yHzZFGHeEemXZLuVVkpDrQ" type="StateMachine_RegionCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_yHzZFWHeEemXZLuVVkpDrQ" type="Region_Shape">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_yHzZFmHeEemXZLuVVkpDrQ" source="RegionAnnotationKey">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_yHzZF2HeEemXZLuVVkpDrQ" key="RegionZoneKey" value=""/>
+          </eAnnotations>
+          <children xmi:type="notation:BasicCompartment" xmi:id="_yHzZGGHeEemXZLuVVkpDrQ" type="Region_SubvertexCompartment">
+            <children xmi:type="notation:Shape" xmi:id="_4XxF0GHfEemXZLuVVkpDrQ" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_4XxF0mHfEemXZLuVVkpDrQ" type="State_NameLabel"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_4XxF02HfEemXZLuVVkpDrQ" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_4XxF1GHfEemXZLuVVkpDrQ" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_4Xxs4GHfEemXZLuVVkpDrQ" type="State_RegionCompartment">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4Xxs4WHfEemXZLuVVkpDrQ"/>
+              </children>
+              <element xmi:type="uml:State" href="pseudostate-in-submachineref.uml#_4XtbcGHfEemXZLuVVkpDrQ"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_4XxF0WHfEemXZLuVVkpDrQ" x="160" y="58"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_5Zir4GHfEemXZLuVVkpDrQ" type="Pseudostate_InitialShape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_5Zir4mHfEemXZLuVVkpDrQ" type="Pseudostate_InitialFloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_5Zir42HfEemXZLuVVkpDrQ" x="25" y="3"/>
+              </children>
+              <children xmi:type="notation:DecorationNode" xmi:id="_5Zir5GHfEemXZLuVVkpDrQ" type="Pseudostate_InitialStereotypeLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_5Zir5WHfEemXZLuVVkpDrQ" x="25" y="-10"/>
+              </children>
+              <element xmi:type="uml:Pseudostate" href="pseudostate-in-submachineref.uml#_5ZdMUGHfEemXZLuVVkpDrQ"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5Zir4WHfEemXZLuVVkpDrQ" x="29" y="70"/>
+            </children>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yHzZGWHeEemXZLuVVkpDrQ"/>
+          </children>
+          <element xmi:type="uml:Region" href="pseudostate-in-submachineref.uml#_yHyyAGHeEemXZLuVVkpDrQ"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yHzZGmHeEemXZLuVVkpDrQ" width="700" height="280"/>
+        </children>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yHzZG2HeEemXZLuVVkpDrQ" y="20" width="700" height="280"/>
+      </children>
+      <element xmi:type="uml:StateMachine" href="pseudostate-in-submachineref.uml#_yHyK8GHeEemXZLuVVkpDrQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_yHzZHGHeEemXZLuVVkpDrQ" x="30" y="30" width="700" height="300"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_yHzZHWHeEemXZLuVVkpDrQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_yHzZHmHeEemXZLuVVkpDrQ"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_yHzZH2HeEemXZLuVVkpDrQ" diagramKindId="org.eclipse.papyrus.uml.diagram.stateMachine">
+      <owner xmi:type="uml:Model" href="pseudostate-in-submachineref.uml#_yHny4GHeEemXZLuVVkpDrQ"/>
+    </styles>
+    <element xmi:type="uml:StateMachine" href="pseudostate-in-submachineref.uml#_yHyK8GHeEemXZLuVVkpDrQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_6xzfUGHfEemXZLuVVkpDrQ" type="Transition_Edge" source="_5Zir4GHfEemXZLuVVkpDrQ" target="_4XxF0GHfEemXZLuVVkpDrQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_6xzfU2HfEemXZLuVVkpDrQ" type="Transition_NameLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8xHrsGHfEemXZLuVVkpDrQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6xzfVGHfEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6xzfVWHfEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8xOZYGHfEemXZLuVVkpDrQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6xzfVmHfEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_6xzfV2HfEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+        <styles xmi:type="notation:BooleanValueStyle" xmi:id="_8xSq0GHfEemXZLuVVkpDrQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_6xzfWGHfEemXZLuVVkpDrQ" y="59"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_6xzfUWHfEemXZLuVVkpDrQ"/>
+      <element xmi:type="uml:Transition" href="pseudostate-in-submachineref.uml#_6xrjgGHfEemXZLuVVkpDrQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_6xzfUmHfEemXZLuVVkpDrQ" points="[78, 133, -643984, -643984]$[191, 140, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6yDW8GHfEemXZLuVVkpDrQ" id="(0.9,0.5)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_6yDW8WHfEemXZLuVVkpDrQ" id="(0.0,0.2727272727272727)"/>
+    </edges>
+  </notation:Diagram>
+  <notation:Diagram xmi:id="_o0eXEWHfEemXZLuVVkpDrQ" type="PapyrusUMLStateMachineDiagram" name="SubStateMachine Diagram" measurementUnit="Pixel">
+    <children xmi:type="notation:Shape" xmi:id="_o0eXEmHfEemXZLuVVkpDrQ" type="StateMachine_Shape">
+      <children xmi:type="notation:DecorationNode" xmi:id="_o0eXE2HfEemXZLuVVkpDrQ" type="StateMachine_NameLabel">
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o0eXFGHfEemXZLuVVkpDrQ" width="700" height="20"/>
+      </children>
+      <children xmi:type="notation:BasicCompartment" xmi:id="_o0eXFWHfEemXZLuVVkpDrQ" type="StateMachine_RegionCompartment">
+        <children xmi:type="notation:Shape" xmi:id="_o0eXFmHfEemXZLuVVkpDrQ" type="Region_Shape">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_o0eXF2HfEemXZLuVVkpDrQ" source="RegionAnnotationKey">
+            <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_o0eXGGHfEemXZLuVVkpDrQ" key="RegionZoneKey" value=""/>
+          </eAnnotations>
+          <children xmi:type="notation:BasicCompartment" xmi:id="_o0eXGWHfEemXZLuVVkpDrQ" type="Region_SubvertexCompartment">
+            <children xmi:type="notation:Shape" xmi:id="__zi64GHfEemXZLuVVkpDrQ" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="__zi64mHfEemXZLuVVkpDrQ" type="State_NameLabel"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="__zi642HfEemXZLuVVkpDrQ" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="__zi65GHfEemXZLuVVkpDrQ" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="__zjh8GHfEemXZLuVVkpDrQ" type="State_RegionCompartment">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="__zjh8WHfEemXZLuVVkpDrQ"/>
+              </children>
+              <element xmi:type="uml:State" href="pseudostate-in-submachineref.uml#__zdbUGHfEemXZLuVVkpDrQ"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="__zi64WHfEemXZLuVVkpDrQ" x="170" y="55"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_A00xsGHgEemXZLuVVkpDrQ" type="Pseudostate_ChoiceShape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_A00xsmHgEemXZLuVVkpDrQ" type="Pseudostate_ChoiceFloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_A00xs2HgEemXZLuVVkpDrQ" x="8" y="-19"/>
+              </children>
+              <children xmi:type="notation:DecorationNode" xmi:id="_A00xtGHgEemXZLuVVkpDrQ" type="Pseudostate_ChoiceStereotypeLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_A00xtWHgEemXZLuVVkpDrQ" x="25" y="-10"/>
+              </children>
+              <element xmi:type="uml:Pseudostate" href="pseudostate-in-submachineref.uml#_A0uEAGHgEemXZLuVVkpDrQ"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_A00xsWHgEemXZLuVVkpDrQ" x="301" y="69"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_CkupEGHgEemXZLuVVkpDrQ" type="State_Shape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_CkupEmHgEemXZLuVVkpDrQ" type="State_NameLabel"/>
+              <children xmi:type="notation:DecorationNode" xmi:id="_CkupE2HgEemXZLuVVkpDrQ" type="State_FloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_CkupFGHgEemXZLuVVkpDrQ" x="40"/>
+              </children>
+              <children xmi:type="notation:BasicCompartment" xmi:id="_CkupFWHgEemXZLuVVkpDrQ" type="State_RegionCompartment">
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CkupFmHgEemXZLuVVkpDrQ"/>
+              </children>
+              <element xmi:type="uml:State" href="pseudostate-in-submachineref.uml#_Ckn7YGHgEemXZLuVVkpDrQ"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_CkupEWHgEemXZLuVVkpDrQ" x="449" y="50"/>
+            </children>
+            <children xmi:type="notation:Shape" xmi:id="_Ei8pQGHgEemXZLuVVkpDrQ" type="Pseudostate_InitialShape">
+              <children xmi:type="notation:DecorationNode" xmi:id="_Ei8pQmHgEemXZLuVVkpDrQ" type="Pseudostate_InitialFloatingNameLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_Ei8pQ2HgEemXZLuVVkpDrQ" x="25" y="3"/>
+              </children>
+              <children xmi:type="notation:DecorationNode" xmi:id="_Ei8pRGHgEemXZLuVVkpDrQ" type="Pseudostate_InitialStereotypeLabel">
+                <layoutConstraint xmi:type="notation:Location" xmi:id="_Ei8pRWHgEemXZLuVVkpDrQ" x="25" y="-10"/>
+              </children>
+              <element xmi:type="uml:Pseudostate" href="pseudostate-in-submachineref.uml#_Ei1UgGHgEemXZLuVVkpDrQ"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_Ei8pQWHgEemXZLuVVkpDrQ" x="29" y="70"/>
+            </children>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o0eXGmHfEemXZLuVVkpDrQ"/>
+          </children>
+          <element xmi:type="uml:Region" href="pseudostate-in-submachineref.uml#_o0eXEGHfEemXZLuVVkpDrQ"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o0eXG2HfEemXZLuVVkpDrQ" width="700" height="280"/>
+        </children>
+        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o0eXHGHfEemXZLuVVkpDrQ" y="20" width="700" height="280"/>
+      </children>
+      <element xmi:type="uml:StateMachine" href="pseudostate-in-submachineref.uml#_mvkgEGHfEemXZLuVVkpDrQ"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_o0eXHWHfEemXZLuVVkpDrQ" x="30" y="30" width="700" height="300"/>
+    </children>
+    <styles xmi:type="notation:StringValueStyle" xmi:id="_o0eXHmHfEemXZLuVVkpDrQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
+    <styles xmi:type="notation:DiagramStyle" xmi:id="_o0eXH2HfEemXZLuVVkpDrQ"/>
+    <styles xmi:type="style:PapyrusDiagramStyle" xmi:id="_o0eXIGHfEemXZLuVVkpDrQ" diagramKindId="org.eclipse.papyrus.uml.diagram.stateMachine">
+      <owner xmi:type="uml:Model" href="pseudostate-in-submachineref.uml#_yHny4GHeEemXZLuVVkpDrQ"/>
+    </styles>
+    <element xmi:type="uml:StateMachine" href="pseudostate-in-submachineref.uml#_mvkgEGHfEemXZLuVVkpDrQ"/>
+    <edges xmi:type="notation:Connector" xmi:id="_GJGHsGHgEemXZLuVVkpDrQ" type="Transition_Edge" source="_Ei8pQGHgEemXZLuVVkpDrQ" target="__zi64GHfEemXZLuVVkpDrQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_GJGHs2HgEemXZLuVVkpDrQ" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GJGHtGHgEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GJGHtWHgEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GJGHtmHgEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_GJGHt2HgEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_GJGHuGHgEemXZLuVVkpDrQ" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_GJGHsWHgEemXZLuVVkpDrQ"/>
+      <element xmi:type="uml:Transition" href="pseudostate-in-submachineref.uml#_GI7voGHgEemXZLuVVkpDrQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_GJGHsmHgEemXZLuVVkpDrQ" points="[78, 131, -643984, -643984]$[201, 120, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GJaQwGHgEemXZLuVVkpDrQ" id="(0.9,0.5800000000000012)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GJaQwWHgEemXZLuVVkpDrQ" id="(0.0,0.3409090909090909)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_Gx4mAGHgEemXZLuVVkpDrQ" type="Transition_Edge" source="__zi64GHfEemXZLuVVkpDrQ" target="_A00xsGHgEemXZLuVVkpDrQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_Gx4mA2HgEemXZLuVVkpDrQ" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Gx4mBGHgEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Gx4mBWHgEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Gx4mBmHgEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_Gx4mB2HgEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_Gx4mCGHgEemXZLuVVkpDrQ" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_Gx4mAWHgEemXZLuVVkpDrQ"/>
+      <element xmi:type="uml:Transition" href="pseudostate-in-submachineref.uml#_Gxu1AGHgEemXZLuVVkpDrQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_Gx4mAmHgEemXZLuVVkpDrQ" points="[241, 120, -643984, -643984]$[340, 126, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GyMvEGHgEemXZLuVVkpDrQ" id="(1.0,0.3409090909090909)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_GyNWIGHgEemXZLuVVkpDrQ" id="(0.13333333333333333,0.3666666666666664)"/>
+    </edges>
+    <edges xmi:type="notation:Connector" xmi:id="_HjgQMGHgEemXZLuVVkpDrQ" type="Transition_Edge" source="_A00xsGHgEemXZLuVVkpDrQ" target="_CkupEGHgEemXZLuVVkpDrQ">
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjgQM2HgEemXZLuVVkpDrQ" type="Transition_NameLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjgQNGHgEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjgQNWHgEemXZLuVVkpDrQ" type="Transition_GuardLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjgQNmHgEemXZLuVVkpDrQ"/>
+      </children>
+      <children xmi:type="notation:DecorationNode" xmi:id="_HjgQN2HgEemXZLuVVkpDrQ" type="Transition_StereotypeLabel">
+        <layoutConstraint xmi:type="notation:Location" xmi:id="_HjgQOGHgEemXZLuVVkpDrQ" y="60"/>
+      </children>
+      <styles xmi:type="notation:FontStyle" xmi:id="_HjgQMWHgEemXZLuVVkpDrQ"/>
+      <element xmi:type="uml:Transition" href="pseudostate-in-submachineref.uml#_HjQ_oGHgEemXZLuVVkpDrQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_HjgQMmHgEemXZLuVVkpDrQ" points="[380, 125, -643984, -643984]$[480, 120, -643984, -643984]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hj3ckGHgEemXZLuVVkpDrQ" id="(0.8,0.3)"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_Hj3ckWHgEemXZLuVVkpDrQ" id="(0.0,0.45454545454545453)"/>
+    </edges>
+  </notation:Diagram>
+</xmi:XMI>

--- a/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachineref.uml
+++ b/spring-statemachine-uml/src/test/resources/org/springframework/statemachine/uml/pseudostate-in-submachineref.uml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<uml:Model xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_yHny4GHeEemXZLuVVkpDrQ" name="pseudostate-in-submachineref">
+  <packageImport xmi:type="uml:PackageImport" xmi:id="_yLWcUGHeEemXZLuVVkpDrQ">
+    <importedPackage xmi:type="uml:Model" href="pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml#_0"/>
+  </packageImport>
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_yHyK8GHeEemXZLuVVkpDrQ" name="StateMachine">
+    <region xmi:type="uml:Region" xmi:id="_yHyyAGHeEemXZLuVVkpDrQ" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_6xrjgGHfEemXZLuVVkpDrQ" source="_5ZdMUGHfEemXZLuVVkpDrQ" target="_4XtbcGHfEemXZLuVVkpDrQ"/>
+      <subvertex xmi:type="uml:State" xmi:id="_4XtbcGHfEemXZLuVVkpDrQ" name="S1" submachine="_mvkgEGHfEemXZLuVVkpDrQ"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_5ZdMUGHfEemXZLuVVkpDrQ" name=""/>
+    </region>
+  </packagedElement>
+  <packagedElement xmi:type="uml:StateMachine" xmi:id="_mvkgEGHfEemXZLuVVkpDrQ" name="SubStateMachine" submachineState="_4XtbcGHfEemXZLuVVkpDrQ">
+    <region xmi:type="uml:Region" xmi:id="_o0eXEGHfEemXZLuVVkpDrQ" name="Region1">
+      <transition xmi:type="uml:Transition" xmi:id="_GI7voGHgEemXZLuVVkpDrQ" source="_Ei1UgGHgEemXZLuVVkpDrQ" target="__zdbUGHfEemXZLuVVkpDrQ"/>
+      <transition xmi:type="uml:Transition" xmi:id="_Gxu1AGHgEemXZLuVVkpDrQ" source="__zdbUGHfEemXZLuVVkpDrQ" target="_A0uEAGHgEemXZLuVVkpDrQ"/>
+      <transition xmi:type="uml:Transition" xmi:id="_HjQ_oGHgEemXZLuVVkpDrQ" source="_A0uEAGHgEemXZLuVVkpDrQ" target="_Ckn7YGHgEemXZLuVVkpDrQ"/>
+      <subvertex xmi:type="uml:State" xmi:id="__zdbUGHfEemXZLuVVkpDrQ" name="S11"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_A0uEAGHgEemXZLuVVkpDrQ" name="CHOICE" kind="choice"/>
+      <subvertex xmi:type="uml:State" xmi:id="_Ckn7YGHgEemXZLuVVkpDrQ" name="S12"/>
+      <subvertex xmi:type="uml:Pseudostate" xmi:id="_Ei1UgGHgEemXZLuVVkpDrQ"/>
+    </region>
+  </packagedElement>
+</uml:Model>


### PR DESCRIPTION
- In a case where uml is drawn with submachine references where
  a pseudostate like choice is defined in a reference, UmlModelParser
  needs to find possible parent by following machine/state references
  to match a state name which references to a this particular machine.
- Actual bug was because pseudostate parent wasn't found it became null,
  thus causing it to be defined in a root machine which then caused
  other cascading errors like nasty loop shown in #729.
- Fixes #729