### PR TITLE
Move post state interceptor call later

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -930,7 +930,6 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		if (isComplete()) {
 			stop();
 		}
-		callPostStateChangeInterceptors(toState, message, transition, stateMachine);
 	}
 
 	private State<S,E> followLinkedPseudoStates(State<S,E> state, StateContext<S, E> stateContext) {
@@ -1259,6 +1258,9 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		if (state == null) {
 			return;
 		}
+		// call post interceptors here instead end of switchToState
+		// as anonymous transition would cause post calls to happen on wrong order
+		callPostStateChangeInterceptors(state, message, transition, stateMachine);
 		log.debug("Trying Enter state=[" + state + "]");
 		if (log.isTraceEnabled()) {
 			log.trace("Trying Enter state=[" + state + "]");


### PR DESCRIPTION
- This is fixing some issues where anonymous transitions
  are causing post state call to happen too early i.e.
  with a submachine which transits away from it.
- Fixes #734