### PR TITLE
Add reactive state actions

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/StateConfigurer.java
@@ -17,13 +17,17 @@ package org.springframework.statemachine.config.configurers;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.Function;
 
+import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerBuilder;
 import org.springframework.statemachine.state.State;
+
+import reactor.core.publisher.Mono;
 
 /**
  * Base {@code StateConfigurer} interface for configuring {@link State}s.
@@ -138,6 +142,33 @@ public interface StateConfigurer<S, E> extends
 	 * @return configurer for chaining
 	 */
 	StateConfigurer<S, E> stateDo(S state, Action<S, E> action, Action<S, E> error);
+
+	/**
+	 * Specify a state {@code S} with state behaviour {@link Function}.
+	 *
+	 * @param state the state
+	 * @param action the state action
+	 * @return configurer for chaining
+	 */
+	StateConfigurer<S, E> stateDoFunction(S state, Function<StateContext<S, E>, Mono<Void>> action);
+
+	/**
+	 * Specify a state {@code S} with state entry {@link Function}.
+	 *
+	 * @param state the state
+	 * @param action the state action
+	 * @return configurer for chaining
+	 */
+	StateConfigurer<S, E> stateEntryFunction(S state, Function<StateContext<S, E>, Mono<Void>> action);
+
+	/**
+	 * Specify a state {@code S} with state exit {@link Function}.
+	 *
+	 * @param state the state
+	 * @param action the state action
+	 * @return configurer for chaining
+	 */
+	StateConfigurer<S, E> stateExitFunction(S state, Function<StateContext<S, E>, Mono<Void>> action);
 
 	/**
 	 * Specify a state {@code S} with entry and exit {@link Action}s.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.action;
 
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurerTests.java
@@ -34,6 +34,8 @@ import org.springframework.statemachine.config.builders.StateMachineStateBuilder
 import org.springframework.statemachine.config.model.StateData;
 import org.springframework.statemachine.state.PseudoStateKind;
 
+import reactor.core.publisher.Mono;
+
 public class DefaultStateConfigurerTests {
 
 	@Test
@@ -134,6 +136,26 @@ public class DefaultStateConfigurerTests {
 		assertThat(builder.data.iterator().next().getExitActions(), nullValue());
 		assertThat(builder.data.iterator().next().getStateActions(), notNullValue());
 		assertThat(builder.data.iterator().next().getEntryActions(), nullValue());
+	}
+
+	@Test
+	public void testStateActionFunctions() throws Exception {
+		DefaultStateConfigurer<TestStates, TestEvents> configurer = new DefaultStateConfigurer<TestStates, TestEvents>();
+		TestStateMachineStateBuilder builder = new TestStateMachineStateBuilder();
+		configurer.stateDoFunction(TestStates.S2, context -> Mono.empty());
+		configurer.stateEntryFunction(TestStates.S2, context -> Mono.empty());
+		configurer.stateExitFunction(TestStates.S2, context -> Mono.empty());
+		configurer.configure(builder);
+		assertThat(builder.data, notNullValue());
+		assertThat(builder.data.size(), is(1));
+
+		assertThat(builder.data.iterator().next().getState(), is(TestStates.S2));
+		assertThat(builder.data.iterator().next().getExitActions(), notNullValue());
+		assertThat(builder.data.iterator().next().getExitActions().size(), is(1));
+		assertThat(builder.data.iterator().next().getStateActions(), notNullValue());
+		assertThat(builder.data.iterator().next().getStateActions().size(), is(1));
+		assertThat(builder.data.iterator().next().getEntryActions(), notNullValue());
+		assertThat(builder.data.iterator().next().getEntryActions().size(), is(1));
 	}
 
 	@Test


### PR DESCRIPTION
- Add stateDoFunction, stateEntryFunction and stateExitFunction methods
  taking Function with a state to register reactive actions.
- Don't yet to a full take on all similar action methods as we need
  to think about how these should be named and what old methods to
  depecate.
- Relates #743