### PR TITLE
Testing polish and generic reactive changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,10 @@ configure(subprojects) { subproject ->
 project('spring-statemachine-core') {
 	description = "Spring State Machine Core"
 
+	configurations {
+		testArtifacts.extendsFrom testRuntime
+	}
+
 	dependencies {
 		compile "org.springframework:spring-tx"
 		compile "org.springframework:spring-messaging"
@@ -193,6 +197,15 @@ project('spring-statemachine-core') {
 		testCompile "javax.servlet:javax.servlet-api"
 		testCompile "org.awaitility:awaitility"
 		testRuntime "org.apache.logging.log4j:log4j-core"
+	}
+
+	task testJar(type: Jar) {
+		classifier = 'tests'
+		from sourceSets.test.output
+	}
+
+	artifacts {
+		testArtifacts testJar
 	}
 }
 
@@ -228,11 +241,14 @@ project('spring-statemachine-test') {
 	dependencies {
 		compile "org.springframework:spring-context"
 		compile project(":spring-statemachine-core")
-
 		compile "org.springframework:spring-test"
 		compile "org.hamcrest:hamcrest-core"
 		compile "org.hamcrest:hamcrest-library"
 		compile "junit:junit"
+		compile "org.assertj:assertj-core"
+		testCompile("org.mockito:mockito-core") { dep ->
+			exclude group: "org.hamcrest"
+		}
 	}
 }
 
@@ -362,10 +378,12 @@ project('spring-statemachine-build-tests') {
 		testCompile project(":spring-statemachine-data-common:spring-statemachine-data-jpa")
 		testCompile project(":spring-statemachine-data-common:spring-statemachine-data-redis")
 		testCompile project(":spring-statemachine-data-common:spring-statemachine-data-mongodb")
-        testCompile "org.apache.commons:commons-pool2"
+		testCompile project(path:":spring-statemachine-core", configuration:"testArtifacts")
+		testCompile "io.projectreactor:reactor-test"
+		testCompile "org.apache.commons:commons-pool2"
 		testRuntime "org.springframework.boot:spring-boot-starter-data-mongodb"
 		testRuntime "org.springframework.boot:spring-boot-starter-data-redis"
-        testRuntime "redis.clients:jedis"
+		testRuntime "redis.clients:jedis"
 		testCompile "org.springframework.boot:spring-boot-starter-data-jpa"
 		testCompile "com.h2database:h2"
 		testCompile "org.springframework.boot:spring-boot-starter"

--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/Gh737Tests.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/Gh737Tests.java
@@ -17,6 +17,9 @@ package org.springframework.statemachine.buildtests;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -31,15 +34,14 @@ import org.springframework.statemachine.guard.Guard;
 public class Gh737Tests extends AbstractBuildTests {
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void test() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<Status, Event> machine = context.getBean(StateMachine.class);
-		machine.start();
+		StateMachine<Status, Event> machine = resolveMachine(context);
+		doStartAndAssert(machine);
 
 		assertThat(machine.getState().getIds(), containsInAnyOrder(Status.ROOT, Status.S0));
-		machine.sendEvent(Event.NEW);
+		doSendEventAndConsumeAll(machine, Event.NEW);
 
 		assertThat(machine.getState().getIds(), containsInAnyOrder(Status.ROOT, Status.S2, Status.S21I, Status.S22I,
 				Status.S23_IN_PROGRESS, Status.S24E));

--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/TimerSmokeTests.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/TimerSmokeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 package org.springframework.statemachine.buildtests;
+
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.doStopAndAssert;
 
 import org.junit.Test;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -30,7 +34,6 @@ public class TimerSmokeTests {
 	}
 
 	private StateMachine<String, String> buildMachine() throws Exception {
-
 		StateMachineBuilder.Builder<String, String> builder = StateMachineBuilder.builder();
 
 		builder.configureConfiguration()
@@ -56,7 +59,6 @@ public class TimerSmokeTests {
 	}
 
 	private StateMachine<String, String> buildMachine2() throws Exception {
-
 		StateMachineBuilder.Builder<String, String> builder = StateMachineBuilder.builder();
 
 		builder.configureConfiguration()
@@ -91,25 +93,23 @@ public class TimerSmokeTests {
 		StateMachine<String, String> stateMachine;
 		for (int i = 0; i < 20; i++) {
 			stateMachine = buildMachine();
-			stateMachine.start();
+			doStartAndAssert(stateMachine);
 			while (!stateMachine.isComplete()) {
-				stateMachine.sendEvent("repeate");
+				doSendEventAndConsumeAll(stateMachine, "repeate");
 			}
 		}
 	}
 
 	@Test
 	public void testNPE2() throws Exception {
-
 		StateMachine<String, String> stateMachine;
-
 		for (int i = 0; i < 20; i++) {
 			stateMachine = buildMachine2();
-			stateMachine.start();
+			doStartAndAssert(stateMachine);
 			while(!stateMachine.isComplete()) {
-				stateMachine.sendEvent("repeate");
+				doSendEventAndConsumeAll(stateMachine, "repeate");
 			}
-			stateMachine.stop();
+			doStopAndAssert(stateMachine);
 		}
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventHeaderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventHeaderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.statemachine;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -44,12 +47,11 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		return new AnnotationConfigApplicationContext();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedToInitialInSubs1() throws InterruptedException {
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1I = context.getBean("headerTestAction1I", HeaderTestAction.class);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
@@ -58,14 +60,14 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
@@ -80,7 +82,7 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		headerTestAction111.testHeader = null;
 
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -90,12 +92,11 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, is("testValue"));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedToInitialInSubs2() throws InterruptedException {
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
 		HeaderTestAction headerTestAction111 = context.getBean("headerTestAction111", HeaderTestAction.class);
@@ -103,14 +104,14 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
@@ -124,7 +125,7 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		headerTestAction111.testHeader = null;
 
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E2").build());
+		doSendEventAndConsumeAll(machine, "E2");
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -134,12 +135,11 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, nullValue());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedToInitialInSubs3() throws InterruptedException {
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1I = context.getBean("headerTestAction1I", HeaderTestAction.class);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
@@ -148,19 +148,19 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -170,7 +170,7 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		headerTestAction111.testHeader = null;
 		headerTestAction112.testHeader = null;
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E3").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E3").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -181,12 +181,11 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, nullValue());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedToInitialInSubs1Threading() throws InterruptedException {
 		context.register(Config2.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1I = context.getBean("headerTestAction1I", HeaderTestAction.class);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
@@ -195,14 +194,14 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
@@ -217,7 +216,7 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		headerTestAction111.testHeader = null;
 
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -227,12 +226,11 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, is("testValue"));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedToInitialInSubs2Threading() throws InterruptedException {
 		context.register(Config2.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
 		HeaderTestAction headerTestAction111 = context.getBean("headerTestAction111", HeaderTestAction.class);
@@ -240,14 +238,14 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
@@ -261,7 +259,7 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		headerTestAction111.testHeader = null;
 
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E2").build());
+		doSendEventAndConsumeAll(machine, "E2");
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -271,12 +269,11 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, nullValue());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedToInitialInSubs3Threading() throws InterruptedException {
 		context.register(Config2.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1I = context.getBean("headerTestAction1I", HeaderTestAction.class);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction11 = context.getBean("headerTestAction11", HeaderTestAction.class);
@@ -285,19 +282,19 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E2").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -307,7 +304,7 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		headerTestAction111.testHeader = null;
 		headerTestAction112.testHeader = null;
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload("E3").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E3").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
@@ -318,26 +315,25 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction112.testHeader, nullValue());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedWithAnonymousTransition() throws InterruptedException {
 		context.register(Config3.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction2 = context.getBean("headerTestAction2", HeaderTestAction.class);
 		HeaderTestAction headerTestAction3 = context.getBean("headerTestAction3", HeaderTestAction.class);
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 
@@ -346,26 +342,25 @@ public class EventHeaderTests extends AbstractStateMachineTests {
 		assertThat(headerTestAction3.testHeader, is("testValue"));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testHeaderPassedWithAnonymousTransitionThreading() throws InterruptedException {
 		context.register(Config4.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		HeaderTestAction headerTestAction1 = context.getBean("headerTestAction1", HeaderTestAction.class);
 		HeaderTestAction headerTestAction2 = context.getBean("headerTestAction2", HeaderTestAction.class);
 		HeaderTestAction headerTestAction3 = context.getBean("headerTestAction3", HeaderTestAction.class);
 		TestListener listener = new TestListener();
 		listener.reset(1);
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload("E1").setHeader("testHeader", "testValue").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/ReactiveTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/ReactiveTests.java
@@ -18,7 +18,6 @@ package org.springframework.statemachine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.springframework.statemachine.assertj.StateMachineAsserts.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +72,7 @@ public class ReactiveTests extends AbstractStateMachineTests {
 
 		StepVerifier.create(machine.sendEvent(asMono(TestEvents.E1)))
 			.assertNext(r -> {
-				assertThat(r).hasResultType(ResultType.ACCEPTED);
+				assertThat(r.getResultType()).isSameAs(ResultType.ACCEPTED);
 				assertThat(machine.getState().getIds()).containsExactlyInAnyOrder(TestStates.S2);
 			})
 			.expectComplete()
@@ -81,7 +80,7 @@ public class ReactiveTests extends AbstractStateMachineTests {
 
 		StepVerifier.create(machine.sendEvent(asMono(TestEvents.E2)))
 			.assertNext(r -> {
-				assertThat(r).hasResultType(ResultType.ACCEPTED);
+				assertThat(r.getResultType()).isSameAs(ResultType.ACCEPTED);
 				assertThat(machine.getState().getIds()).containsExactlyInAnyOrder(TestStates.S3);
 			})
 			.expectComplete()
@@ -182,7 +181,7 @@ public class ReactiveTests extends AbstractStateMachineTests {
 
 		StepVerifier.create(machine.sendEvent(asMono("E1")))
 			.assertNext(r -> {
-				assertThat(r).hasResultType(ResultType.ACCEPTED);
+				assertThat(r.getResultType()).isSameAs(ResultType.ACCEPTED);
 				assertThat(machine.getState().getIds()).containsExactlyInAnyOrder("S1");
 			})
 			.expectComplete()
@@ -190,7 +189,7 @@ public class ReactiveTests extends AbstractStateMachineTests {
 
 		StepVerifier.create(machine.sendEvent(asMono("E3")))
 			.assertNext(r -> {
-				assertThat(r).hasResultType(ResultType.DEFERRED);
+				assertThat(r.getResultType()).isSameAs(ResultType.DEFERRED);
 				assertThat(machine.getState().getIds()).containsExactlyInAnyOrder("S1");
 			})
 			.expectComplete()
@@ -198,7 +197,7 @@ public class ReactiveTests extends AbstractStateMachineTests {
 
 		StepVerifier.create(machine.sendEvent(asMono("E2")))
 			.assertNext(r -> {
-				assertThat(r).hasResultType(ResultType.ACCEPTED);
+				assertThat(r.getResultType()).isSameAs(ResultType.ACCEPTED);
 				assertThat(machine.getState().getIds()).containsExactlyInAnyOrder("S3");
 			})
 			.expectComplete()
@@ -226,8 +225,8 @@ public class ReactiveTests extends AbstractStateMachineTests {
 			.expectComplete()
 			.verify();
 
-		assertThat(ers).filteredOnAssertions(er -> assertThat(er).hasResultType(ResultType.ACCEPTED)).hasSize(1);
-		assertThat(ers).filteredOnAssertions(er -> assertThat(er).hasResultType(ResultType.DENIED)).hasSize(1);
+		assertThat(ers).filteredOnAssertions(er -> assertThat(er.getResultType()).isSameAs(ResultType.ACCEPTED)).hasSize(1);
+		assertThat(ers).filteredOnAssertions(er -> assertThat(er.getResultType()).isSameAs(ResultType.DENIED)).hasSize(1);
 		assertThat(machine.getState().getIds()).containsExactlyInAnyOrder(TestStates.S11, TestStates.S20);
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateContextTests.java
@@ -23,6 +23,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -49,17 +52,16 @@ public class StateContextTests extends AbstractStateMachineTests {
 		return new AnnotationConfigApplicationContext();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testStartCycles() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
 		TestStateMachineListener listener = new TestStateMachineListener();
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S11));
 		assertThat(listener.contexts, hasSize(19));
 
@@ -150,20 +152,19 @@ public class StateContextTests extends AbstractStateMachineTests {
 		assertThat(listener.contexts.get(18).getTransition(), notNullValue());
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testEventNotAccepted() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
 		TestStateMachineListener listener = new TestStateMachineListener();
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		listener.contexts.clear();
 
-		machine.sendEvent(Events.J);
+		doSendEventAndConsumeAll(machine, Events.J);
 
 		// all nested machines sends these
 		assertThat(listener.contexts, contains(

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,11 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.doStopAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -66,8 +71,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetSubStates1() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
 		Map<Object, Object> variables = new HashMap<Object, Object>();
 		variables.put("foo", 1);
@@ -82,7 +86,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S12));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo"), is(1));
 	}
@@ -91,8 +95,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetSubStates2() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
 		Map<Object, Object> variables = new HashMap<Object, Object>();
 		variables.put("foo", 1);
@@ -107,7 +110,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S2, States.S21, States.S211));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo"), is(1));
 	}
@@ -116,8 +119,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetSubStates3() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
 		Map<Object, Object> variables = new HashMap<Object, Object>();
 		variables.put("foo", 1);
@@ -132,7 +134,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S2, States.S21, States.S211));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo"), is(1));
 	}
@@ -141,8 +143,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetRegions1() {
 		context.register(Config2.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<TestStates, TestEvents> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 
 		DefaultStateMachineContext<TestStates, TestEvents> stateMachineContext1 =
 				new DefaultStateMachineContext<TestStates, TestEvents>(TestStates.S21, TestEvents.E2, null, null);
@@ -164,7 +165,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S31));
 	}
 
@@ -172,8 +173,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetRegions2() {
 		context.register(Config2.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<TestStates, TestEvents> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 
 		DefaultStateMachineContext<TestStates, TestEvents> stateMachineContext1 =
 				new DefaultStateMachineContext<TestStates, TestEvents>(TestStates.S21, null, null, null);
@@ -195,7 +195,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S31));
 	}
 
@@ -203,14 +203,13 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetUpdateExtendedStateVariables() {
 		context.register(Config3.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count"), nullValue());
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count"), is(1));
 
-		machine.stop();
+		doStopAndAssert(machine);
 		Map<Object, Object> variables = new HashMap<Object, Object>();
 		variables.putAll(machine.getExtendedState().getVariables());
 		ExtendedState extendedState = new DefaultExtendedState(variables);
@@ -224,9 +223,9 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count"), is(1));
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count"), is(2));
 	}
 
@@ -234,18 +233,17 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetWithNullContext() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S11));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo"), is(0));
 
-		machine.sendEvent(Events.I);
+		doSendEventAndConsumeAll(machine, Events.I);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S12));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo"), is(0));
 
-		machine.stop();
+		doStopAndAssert(machine);
 		machine.getStateMachineAccessor().doWithAllRegions(new StateMachineFunction<StateMachineAccess<States,Events>>() {
 
 			@Override
@@ -253,7 +251,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 				function.resetStateMachine(null);
 			}
 		});
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S11));
 		assertThat(machine.getExtendedState().getVariables().size(), is(0));
 	}
@@ -262,17 +260,15 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetWithEnumToCorrectStartState() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE,
-				StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S11));
 
-		machine.sendEvent(Events.I);
+		doSendEventAndConsumeAll(machine, Events.I);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S12));
 
-		machine.stop();
+		doStopAndAssert(machine);
 		DefaultStateMachineContext<States, Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(
 				States.S11, null, null, null);
 		machine.getStateMachineAccessor()
@@ -283,7 +279,8 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 						function.resetStateMachine(stateMachineContext);
 					}
 				});
-		machine.start();
+
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S11));
 		assertEquals(States.S11, stateMachineContext.getState());
 		assertNotEquals(stateMachineContext.getState(), machine.getInitialState());
@@ -293,9 +290,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testRestoreWithTimer() throws Exception {
 		context.register(Config4.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<States, Events> factory = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY,
-				StateMachineFactory.class);
+		StateMachineFactory<States, Events> factory = resolveFactory(context);
 		StateMachine<States, Events> machine = factory.getStateMachine();
 
 		DefaultStateMachineContext<States, Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S1, null,
@@ -308,7 +303,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		Thread.sleep(1100);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S2));
 
@@ -318,15 +313,14 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 	public void testResetKeepsExtendedStateIntactInSubmachine() {
 		context.register(Config5.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		CountListener listener = new CountListener();
 		machine.addStateListener(listener);
 
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count1"), nullValue());
 		assertThat(listener.count1, nullValue());
 		assertThat(listener.count2, nullValue());
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1, States.S11));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count1"), is(1));
 		assertThat(listener.count1, is(1));
@@ -334,18 +328,18 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		assertThat(listener.count2, nullValue());
 
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count2"), nullValue());
-		machine.sendEvent(Events.B);
+		doSendEventAndConsumeAll(machine, Events.B);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1, States.S12));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count2"), is(1));
 		assertThat(listener.count1, is(1));
 		assertThat(listener.count2, nullValue());
 
-		machine.sendEvent(Events.C);
+		doSendEventAndConsumeAll(machine, Events.C);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 		assertThat(listener.count1, is(1));
 		assertThat(listener.count2, is(1));
 
-		machine.stop();
+		doStopAndAssert(machine);
 		Map<Object, Object> variables = new HashMap<Object, Object>();
 		variables.putAll(machine.getExtendedState().getVariables());
 		ExtendedState extendedState = new DefaultExtendedState(variables);
@@ -358,12 +352,12 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 				function.resetStateMachine(stateMachineContext);
 			}
 		});
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count1"), is(1));
 		assertThat(listener.count1, is(1));
 		assertThat(listener.count2, is(1));
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1, States.S11));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count1"), is(2));
 		assertThat(listener.count1, is(2));
@@ -371,7 +365,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		assertThat(listener.count2, is(1));
 
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count2"), is(1));
-		machine.sendEvent(Events.B);
+		doSendEventAndConsumeAll(machine, Events.B);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1, States.S12));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count2"), is(2));
 		assertThat(listener.count1, is(2));
@@ -383,9 +377,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		context.register(Config6.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachine<MyState, MyEvent> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE,
-				StateMachine.class);
+		StateMachine<MyState, MyEvent> machine = resolveMachine(context);
 
 		DefaultStateMachineContext<MyState, MyEvent> stateMachineContext = new DefaultStateMachineContext<MyState, MyEvent>(
 				SubState.SUB_NEXT, null, null, null);
@@ -398,7 +390,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(SuperState.PARENT, SubState.SUB_NEXT));
 	}
 
@@ -407,9 +399,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		context.register(Config6.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachine<MyState, MyEvent> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE,
-				StateMachine.class);
+		StateMachine<MyState, MyEvent> machine = resolveMachine(context);
 
 		DefaultStateMachineContext<MyState, MyEvent> stateMachineContext = new DefaultStateMachineContext<MyState, MyEvent>(
 				SuperState.INITIAL, null, null, null);
@@ -422,7 +412,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(SuperState.INITIAL));
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/SpelExpressionActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/SpelExpressionActionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package org.springframework.statemachine.action;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.TimeUnit;
 
@@ -29,10 +31,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
@@ -40,19 +40,17 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 
 public class SpelExpressionActionTests extends AbstractStateMachineTests {
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSpelActionSendsEvent() throws Exception {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(Config1.class);
-		assertTrue(ctx.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<TestStates,TestEvents> machine =
-				ctx.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(ctx);
+		doStartAndAssert(machine);
 		TestStateMachineListener listener = new TestStateMachineListener();
 		machine.addStateListener(listener);
-		machine.start();
+		doStartAndAssert(machine);
 		listener.reset(2, 0);
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.stateChangedLatch.await(5, TimeUnit.SECONDS), is(true));
 		assertThat(machine.getState().getIds(), contains(TestStates.S3));
 		ctx.close();

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithBuilderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.statemachine.annotation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
@@ -36,7 +39,6 @@ import org.springframework.statemachine.config.StateMachineBuilder.Builder;
 import org.springframework.statemachine.config.configuration.StateMachineAnnotationPostProcessorConfiguration;
 import org.springframework.statemachine.config.configurers.ConfigurationConfigurer;
 
-@SuppressWarnings("unchecked")
 public class MethodAnnotationWithBuilderTests extends AbstractStateMachineTests {
 
 	@Test
@@ -46,11 +48,11 @@ public class MethodAnnotationWithBuilderTests extends AbstractStateMachineTests 
 
 		Bean1 bean1 = context.getBean(Bean1.class);
 
-		StateMachine<TestStates,TestEvents> machine = context.getBean(StateMachine.class);
-		machine.start();
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
+		doStartAndAssert(machine);
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(machine.getState().getIds(), contains(TestStates.S2));
 		assertThat(bean1.onStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
 	}
@@ -62,11 +64,11 @@ public class MethodAnnotationWithBuilderTests extends AbstractStateMachineTests 
 
 		Bean1 bean1 = context.getBean(Bean1.class);
 
-		StateMachine<TestStates,TestEvents> machine = context.getBean(StateMachine.class);
-		machine.start();
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
+		doStartAndAssert(machine);
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(machine.getState().getIds(), contains(TestStates.S2));
 		assertThat(bean1.onStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
 	}
@@ -78,11 +80,11 @@ public class MethodAnnotationWithBuilderTests extends AbstractStateMachineTests 
 
 		Bean1 bean1 = context.getBean(Bean1.class);
 
-		StateMachine<TestStates,TestEvents> machine = buildMachine(context);
-		machine.start();
+		StateMachine<TestStates, TestEvents> machine = buildMachine(context);
+		doStartAndAssert(machine);
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(machine.getState().getIds(), contains(TestStates.S2));
 		assertThat(bean1.onStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
 	}
@@ -94,11 +96,11 @@ public class MethodAnnotationWithBuilderTests extends AbstractStateMachineTests 
 
 		Bean2 bean2 = context.getBean(Bean2.class);
 
-		StateMachine<TestStates,TestEvents> machine = buildMachine(context);
-		machine.start();
+		StateMachine<TestStates, TestEvents> machine = buildMachine(context);
+		doStartAndAssert(machine);
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(machine.getState().getIds(), contains(TestStates.S2));
 		assertThat(bean2.onStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithFactoryTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithFactoryTests.java
@@ -18,6 +18,9 @@ package org.springframework.statemachine.annotation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
 
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
@@ -29,14 +32,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.config.EnableStateMachineFactory;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.StateMachineFactory;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 
-@SuppressWarnings("unchecked")
 public class MethodAnnotationWithFactoryTests extends AbstractStateMachineTests {
 
 	@Test
@@ -46,13 +47,12 @@ public class MethodAnnotationWithFactoryTests extends AbstractStateMachineTests 
 
 		Bean1 bean1 = context.getBean(Bean1.class);
 
-		StateMachineFactory<TestStates,TestEvents> factory =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+		StateMachineFactory<TestStates,TestEvents> factory = resolveFactory(context);
 		StateMachine<TestStates,TestEvents> machine = factory.getStateMachine("xxx");
-		machine.start();
+		doStartAndAssert(machine);
 
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(machine.getState().getIds(), contains(TestStates.S2));
 		assertThat(bean1.onStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.statemachine.config;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -45,12 +48,11 @@ public class ManualBuilderContextTests extends AbstractStateMachineTests {
 		context.register(Config1.class);
 		context.refresh();
 		TestListener listener = context.getBean(TestListener.class);
-		@SuppressWarnings("unchecked")
-		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+		StateMachine<String, String> stateMachine = resolveMachine(context);
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
 		listener.reset(1);
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2"));
@@ -61,13 +63,12 @@ public class ManualBuilderContextTests extends AbstractStateMachineTests {
 		context.register(Config2.class);
 		context.refresh();
 		TestListener listener = context.getBean(TestListener.class);
-		@SuppressWarnings("unchecked")
-		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
-		stateMachine.start();
+		StateMachine<String, String> stateMachine = resolveMachine(context);
+		doStartAndAssert(stateMachine);
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
 		listener.reset(1);
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2"));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderTests.java
@@ -19,6 +19,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +67,7 @@ public class ManualBuilderTests {
 		TestListener listener = new TestListener();
 		StateMachine<String,String> stateMachine = stateMachineFactory.getStateMachine();
 		stateMachine.addStateListener(listener);
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
@@ -100,7 +102,7 @@ public class ManualBuilderTests {
 		assertThat(stateMachine, notNullValue());
 		TestListener listener = new TestListener();
 		stateMachine.addStateListener(listener);
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
@@ -135,7 +137,7 @@ public class ManualBuilderTests {
 		assertThat(stateMachine, notNullValue());
 		TestListener2 listener = new TestListener2();
 		stateMachine.addStateListener(listener);
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
@@ -143,7 +145,7 @@ public class ManualBuilderTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(MyStates.S1));
 
 		listener.reset(1);
-		stateMachine.sendEvent(MyEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, MyEvents.E1);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(stateMachine, notNullValue());
@@ -174,7 +176,7 @@ public class ManualBuilderTests {
 		assertThat(stateMachine, notNullValue());
 		TestListener listener = new TestListener();
 		stateMachine.addStateListener(listener);
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
@@ -182,7 +184,7 @@ public class ManualBuilderTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
 
 		listener.reset(1);
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(stateMachine, notNullValue());

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelFactoryTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelFactoryTests.java
@@ -18,6 +18,11 @@ package org.springframework.statemachine.config.model;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.doStopAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,9 +66,9 @@ public class StateMachineModelFactoryTests extends AbstractStateMachineTests {
 		ObjectStateMachineFactory<String, String> factory = new ObjectStateMachineFactory<>(modelBuilder.build());
 
 		StateMachine<String,String> stateMachine = factory.getStateMachine();
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine.getState().getIds(), contains("S1"));
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(stateMachine.getState().getIds(), contains("S2"));
 	}
 
@@ -71,12 +76,11 @@ public class StateMachineModelFactoryTests extends AbstractStateMachineTests {
 	public void testFromAnnotationConfig() {
 		context.register(Config2.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+		StateMachine<String, String> stateMachine = resolveMachine(context);
 
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine.getState().getIds(), contains("S1"));
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(stateMachine.getState().getIds(), contains("S2"));
 	}
 
@@ -84,35 +88,33 @@ public class StateMachineModelFactoryTests extends AbstractStateMachineTests {
 	public void testModelRecreates() {
 		context.register(Config3.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<String, String> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<String, String> stateMachineFactory = resolveFactory(context);
 		StateMachine<String,String> stateMachine = stateMachineFactory.getStateMachine();
 		TestStateMachineModelFactory modelFactory = context.getBean(TestStateMachineModelFactory.class);
 
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine.getState().getIds(), contains("S1"));
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(stateMachine.getState().getIds(), contains("S2"));
-		stateMachine.stop();
+		doStopAndAssert(stateMachine);
 
 		modelFactory.state1 = "SS1";
 		modelFactory.state2 = "SS2";
 		modelFactory.event1 = "EE1";
 
 		stateMachine = stateMachineFactory.getStateMachine();
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine.getState().getIds(), contains("SS1"));
-		stateMachine.sendEvent("EE1");
+		doSendEventAndConsumeAll(stateMachine, "EE1");
 		assertThat(stateMachine.getState().getIds(), contains("SS2"));
-		stateMachine.stop();
+		doStopAndAssert(stateMachine);
 	}
 
 	@Test
 	public void testConfigAdapterConfigFromModel() throws Exception {
 		context.register(Config4.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+		StateMachine<String, String> stateMachine = resolveMachine(context);
 
 		Object o1 = TestUtils.readField("stateListener", stateMachine);
 		Object o2 = TestUtils.readField("listeners", o1);
@@ -124,8 +126,7 @@ public class StateMachineModelFactoryTests extends AbstractStateMachineTests {
 	public void testConfigAdapterConfigFromAdapter() throws Exception {
 		context.register(Config5.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<String, String> stateMachine = context.getBean(StateMachine.class);
+		StateMachine<String, String> stateMachine = resolveMachine(context);
 
 		Object o1 = TestUtils.readField("stateListener", stateMachine);
 		Object o2 = TestUtils.readField("listeners", o1);

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,18 @@
  */
 package org.springframework.statemachine.config.model;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.task.SyncTaskExecutor;
@@ -29,12 +41,6 @@ import org.springframework.statemachine.ensemble.StateMachineEnsemble;
 import org.springframework.statemachine.listener.StateMachineListener;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.transition.TransitionKind;
-
-import java.util.*;
-
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
 
 public class StateMachineModelTests {
 
@@ -80,9 +86,9 @@ public class StateMachineModelTests {
 		ObjectStateMachineFactory<String, String> factory = new ObjectStateMachineFactory<>(stateMachineModel);
 
 		StateMachine<String,String> stateMachine = factory.getStateMachine();
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine.getState().getIds(), contains("S1"));
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(stateMachine.getState().getIds(), contains("S2"));
 	}
 
@@ -103,9 +109,9 @@ public class StateMachineModelTests {
 		ObjectStateMachineFactory<String, String> factory = new ObjectStateMachineFactory<>(stateMachineModel);
 
 		StateMachine<String,String> stateMachine = factory.getStateMachine();
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine.getState().getIds(), contains("S1"));
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(stateMachine.getState().getIds(), contains("S2"));
 	}
 
@@ -142,14 +148,14 @@ public class StateMachineModelTests {
 		ObjectStateMachineFactory<String, String> factory = new ObjectStateMachineFactory<>(stateMachineModel);
 
 		StateMachine<String,String> stateMachine = factory.getStateMachine();
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S1"));
-		stateMachine.sendEvent("E1");
+		doSendEventAndConsumeAll(stateMachine, "E1");
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2", "S20"));
-		stateMachine.sendEvent("E2");
+		doSendEventAndConsumeAll(stateMachine, "E2");
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2", "S21", "S30"));
-		stateMachine.sendEvent("E3");
+		doSendEventAndConsumeAll(stateMachine, "E3");
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder("S2", "S21", "S31"));
 	}
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests2.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@ package org.springframework.statemachine.persist;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +67,6 @@ public class StateMachinePersistTests2 extends AbstractStateMachineTests {
 		return new AnnotationConfigApplicationContext();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testVariousPersistOperations() throws Exception {
 		context.register(Config1.class);
@@ -75,13 +75,13 @@ public class StateMachinePersistTests2 extends AbstractStateMachineTests {
 		StateMachinePersister<String, String, String> persister = new DefaultStateMachinePersister<String, String, String>(
 				stateMachinePersist);
 
-		StateMachineFactory<String, String> factory = context.getBean("LOG_RECORD", StateMachineFactory.class);
+		StateMachineFactory<String, String> factory = resolveFactory("LOG_RECORD", context);
 		StateMachine<String,String> m = factory.getStateMachine();
 
 		assertThat(m.getState().getId(), equalTo(RECORD_AWAITING_CONTENT));
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(UPLOAD_RECORD), is(true));
+		doSendEventAndConsumeAll(m, UPLOAD_RECORD);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[] { RECORD_LOGGING_ACTIVE, RECORD_AWAITING_LOGGING }));
 		persister.persist(m, "xxx");
 
@@ -89,7 +89,7 @@ public class StateMachinePersistTests2 extends AbstractStateMachineTests {
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_AWAITING_LOGGING}));
 		persister.persist(m, "xxx");
 
-		assertThat(m.sendEvent(SUSPEND_RECORD_LOGGING), is(true));
+		doSendEventAndConsumeAll(m, SUSPEND_RECORD_LOGGING);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_LOGGING_ON_HOLD}));
 		persister.persist(m, "xxx");
 
@@ -97,47 +97,47 @@ public class StateMachinePersistTests2 extends AbstractStateMachineTests {
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_LOGGING_ON_HOLD}));
 		persister.persist(m, "xxx");
 
-		assertThat(m.sendEvent(START_LOGGING_RECORD), is(true));
+		doSendEventAndConsumeAll(m, START_LOGGING_RECORD);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_IN_PROGRESS}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(CANCEL_RECORD_LOGGING), is(true));
+		doSendEventAndConsumeAll(m, CANCEL_RECORD_LOGGING);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_LOGGING_ON_HOLD}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(RESUME_RECORD_LOGGING), is(true));
+		doSendEventAndConsumeAll(m, RESUME_RECORD_LOGGING);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_AWAITING_LOGGING}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(START_LOGGING_RECORD), is(true));
+		doSendEventAndConsumeAll(m, START_LOGGING_RECORD);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_IN_PROGRESS}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(CANCEL_RECORD_LOGGING), is(true));
+		doSendEventAndConsumeAll(m, CANCEL_RECORD_LOGGING);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_AWAITING_LOGGING}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(SUSPEND_RECORD_LOGGING_WITH_ERROR), is(true));
+		doSendEventAndConsumeAll(m, SUSPEND_RECORD_LOGGING_WITH_ERROR);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ON_HOLD_WITH_ERROR}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(RESUME_RECORD_LOGGING), is(true));
+		doSendEventAndConsumeAll(m, RESUME_RECORD_LOGGING);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_ACTIVE, RECORD_AWAITING_LOGGING}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(START_LOGGING_RECORD), is(true));
+		doSendEventAndConsumeAll(m, START_LOGGING_RECORD);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGING_IN_PROGRESS}));
 		persister.persist(m, "xxx");
 
 		m = loadStateMachine(factory, persister, "xxx");
-		assertThat(m.sendEvent(LOG_RECORD), is(true));
+		doSendEventAndConsumeAll(m, LOG_RECORD);
 		assertThat(m.getState().getIds(), containsInAnyOrder(new String[]{RECORD_LOGGED}));
 		persister.persist(m, "xxx");
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests4.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests4.java
@@ -21,6 +21,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,26 +64,25 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config1.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 		assertThat(stateMachine, notNullValue());
 		assertThat(stateMachine.getId(), is("testid"));
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 		persister.persist(stateMachine, "xxx2");
 
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 		persister.persist(stateMachine, "xxx3");
 
@@ -111,16 +113,15 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config1.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -129,9 +130,9 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -140,16 +141,15 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config1.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -158,18 +158,18 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 
 		stateMachine = persister.restore(stateMachine, "xxx1");
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -178,18 +178,17 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config1.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -197,7 +196,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -206,18 +205,17 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config1.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -226,7 +224,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 
 		stateMachine = persister.restore(stateMachine, "xxx1");
@@ -234,7 +232,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -243,16 +241,15 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config2.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -261,9 +258,9 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -272,16 +269,15 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config2.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -290,18 +286,18 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 
 		stateMachine = persister.restore(stateMachine, "xxx1");
 		assertThat(stateMachine.getId(), is("testid"));
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -310,18 +306,17 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config2.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -330,7 +325,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
@@ -339,18 +334,17 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		context.register(Config2.class);
 		context.refresh();
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
 
 		StateMachine<TestStates, TestEvents> stateMachine = stateMachineFactory.getStateMachine("testid");
-		stateMachine.start();
+		doStartAndAssert(stateMachine);
 
-		stateMachine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E1);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E2);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 		persister.persist(stateMachine, "xxx1");
 
@@ -359,7 +353,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 
 		stateMachine = persister.restore(stateMachine, "xxx1");
@@ -367,18 +361,17 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		stateMachine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(stateMachine, TestEvents.E3);
 		assertThat(stateMachine.getState().getIds(), containsInAnyOrder(TestStates.S4));
 	}
 
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testJoinFromSuperAfterPersistRegions() throws Exception {
 		context.register(Config3.class);
 		context.refresh();
 
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 		StateMachine<TestStates, TestEvents> machine = stateMachineFactory.getStateMachine("testid");
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
@@ -387,12 +380,12 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine.addStateListener(listener);
 		listener.reset(1);
 		assertThat(machine, notNullValue());
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
@@ -401,13 +394,13 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine = persister.restore(machine, "xxx1");
 
 		listener.reset(1);
-		machine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(machine, TestEvents.E2);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		listener.reset(2);
-		machine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(machine, TestEvents.E3);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(2));
 
@@ -419,13 +412,13 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine.addStateListener(listener);
 
 		listener.reset(1);
-		machine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(machine, TestEvents.E2);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 
 		listener.reset(2);
-		machine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(machine, TestEvents.E3);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(2));
 
@@ -433,12 +426,11 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testJoinFromSuperAfterPersistRegionsPartial() throws Exception {
 		context.register(Config3.class);
 		context.refresh();
 
-		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<TestStates, TestEvents> stateMachineFactory = resolveFactory(context);
 		StateMachine<TestStates, TestEvents> machine = stateMachineFactory.getStateMachine("testid");
 		InMemoryStateMachinePersist stateMachinePersist = new InMemoryStateMachinePersist();
 		StateMachinePersister<TestStates, TestEvents, String> persister = new DefaultStateMachinePersister<>(stateMachinePersist);
@@ -447,19 +439,19 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine.addStateListener(listener);
 		listener.reset(1);
 		assertThat(machine, notNullValue());
-		machine.start();
+		doStartAndAssert(machine);
 		assertPseudoStatesHaveOneListener(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 
 		listener.reset(3);
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20, TestStates.S30));
 
 		listener.reset(1);
-		machine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(machine, TestEvents.E2);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
@@ -469,7 +461,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine = persister.restore(machine, "xxx1");
 		assertPseudoStatesHaveOneListener(machine);
 		listener.reset(2);
-		machine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(machine, TestEvents.E3);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(2));
 		assertThat(machine.getState().getIds(), contains(TestStates.S4));
@@ -478,7 +470,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine = persister.restore(machine, "xxx1");
 		assertPseudoStatesHaveOneListener(machine);
 		listener.reset(2);
-		machine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(machine, TestEvents.E3);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(2));
 		assertThat(machine.getState().getIds(), contains(TestStates.S4));
@@ -489,7 +481,7 @@ public class StateMachinePersistTests4 extends AbstractStateMachineTests {
 		machine.addStateListener(listener);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
 		listener.reset(2);
-		machine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(machine, TestEvents.E3);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(2));
 		assertThat(machine.getState().getIds(), contains(TestStates.S4));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/AbstractSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/AbstractSecurityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.statemachine.security;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +43,7 @@ public abstract class AbstractSecurityTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1));
@@ -54,7 +55,7 @@ public abstract class AbstractSecurityTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(false));
 		assertThat(listener.stateChangedCount, is(0));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/ActionSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/ActionSecurityTests.java
@@ -18,6 +18,7 @@ package org.springframework.statemachine.security;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +82,7 @@ public class ActionSecurityTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1));
@@ -96,7 +97,7 @@ public class ActionSecurityTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityExpressionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.statemachine.security;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +73,7 @@ public class TransitionSecurityExpressionTests extends AbstractStateMachineTests
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1));
@@ -84,7 +85,7 @@ public class TransitionSecurityExpressionTests extends AbstractStateMachineTests
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(false));
 		assertThat(listener.stateChangedCount, is(0));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/CompletionEventTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/CompletionEventTests.java
@@ -17,7 +17,9 @@ package org.springframework.statemachine.state;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -27,11 +29,9 @@ import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
@@ -45,19 +45,15 @@ public class CompletionEventTests extends AbstractStateMachineTests {
 		return new AnnotationConfigApplicationContext();
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSimpleStateWithStateActionCompletes() throws Exception {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 		TestCountAction testAction2 = context.getBean("testAction2", TestCountAction.class);
+		doStartAndAssert(machine);
 
-		machine.start();
-
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 
 		assertThat(testAction2.latch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(testAction2.count, is(1));
@@ -65,20 +61,17 @@ public class CompletionEventTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getId(), is("S3"));
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSimpleStateWithStateActionCompletesThreading() throws Exception {
 		context.register(Config1.class, BaseConfig2.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 		TestCountAction testAction2 = context.getBean("testAction2", TestCountAction.class);
 
-		machine.start();
+		doStartAndAssert(machine);
 		Thread.sleep(1000);
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 
 		assertThat(testAction2.latch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(testAction2.count, is(1));
@@ -86,71 +79,59 @@ public class CompletionEventTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getId(), is("S3"));
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSimpleStateWithoutStateActionCompletes() throws Exception {
 		context.register(Config2.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getId(), is("S3"));
 	}
 
 	public void testSubmachineWithStateActionCompletes() throws Exception {
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSubmachineWithoutStateActionCompletes() throws Exception {
 		context.register(Config3.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getId(), is("S3"));
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSubmachineWithoutStateActionCompletes2() throws Exception {
 		context.register(Config5.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getId(), is("S3"));
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testSubmachineWithoutStateActionCompletesThreading() throws Exception {
 		context.register(Config3.class, BaseConfig2.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		Thread.sleep(200);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 		Thread.sleep(200);
 		assertThat(machine.getState().getId(), is("S3"));
 	}
@@ -158,36 +139,30 @@ public class CompletionEventTests extends AbstractStateMachineTests {
 	public void testRegionWithStateActionCompletes() throws Exception {
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testRegionWithoutStateActionCompletes() throws Exception {
 		context.register(Config4.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getId(), is("S3"));
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testRegionWithoutStateActionCompletesWithMultipleEnds1() throws Exception {
 		context.register(Config6.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
-		machine.sendEvent(MessageBuilder.withPayload("E2").build());
+		doSendEventAndConsumeAll(machine, "E1");
+		doSendEventAndConsumeAll(machine, "E2");
 
 		// TODO: REACTOR think this change is because we do subcribe
 		//       with onComplete so things are not fully changed with sendEvent
@@ -195,20 +170,17 @@ public class CompletionEventTests extends AbstractStateMachineTests {
 		// assertThat(machine.getState().getId(), is("S3"));
 	}
 
-	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testRegionWithoutStateActionCompletesWithMultipleEnds2() throws Exception {
 		context.register(Config6.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String,String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String,String> machine = resolveMachine(context);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getId(), is("S1"));
 
-		machine.sendEvent(MessageBuilder.withPayload("E1").build());
-		machine.sendEvent(MessageBuilder.withPayload("E3").build());
+		doSendEventAndConsumeAll(machine, "E1");
+		doSendEventAndConsumeAll(machine, "E3");
 
 		// TODO: REACTOR think this change is because we do subcribe
 		//       with onComplete so things are not fully changed with sendEvent

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefEnumTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefEnumTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.statemachine.state;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +29,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
@@ -42,36 +44,34 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 public class SubmachineRefEnumTests extends AbstractStateMachineTests {
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSubmachineRef() throws Exception {
 		context.register(Config2.class, Config1.class);
 		context.refresh();
-		StateMachine<TestStates, TestEvents> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		assertThat(machine, notNullValue());
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S1));
-		machine.sendEvent(TestEvents.E1);
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S20));
-		machine.sendEvent(TestEvents.E2);
+		doSendEventAndConsumeAll(machine, TestEvents.E2);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S30));
-		machine.sendEvent(TestEvents.E3);
+		doSendEventAndConsumeAll(machine, TestEvents.E3);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(TestStates.S2, TestStates.S21, TestStates.S31));
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSubmachineRefDifferentTypes() throws Exception {
 		context.register(Config4.class, Config3.class);
 		context.refresh();
-		StateMachine<Object, Object> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<Object, Object> machine = resolveMachine(context);
 		assertThat(machine, notNullValue());
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S1));
-		machine.sendEvent(Events1.E1);
+		doSendEventAndConsumeAll(machine, Events1.E1);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S2, States2.S20));
-		machine.sendEvent(Events2.E2);
+		doSendEventAndConsumeAll(machine, Events2.E2);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S2, States2.S21, States2.S30));
-		machine.sendEvent(Events2.E3);
+		doSendEventAndConsumeAll(machine, Events2.E3);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States1.S2, States2.S21, States2.S31));
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@ package org.springframework.statemachine.state;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +30,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnableStateMachineFactory;
 import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
@@ -43,37 +46,35 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 public class SubmachineRefTests extends AbstractStateMachineTests {
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSubmachineRef() throws Exception {
 		context.register(Config2.class, Config1.class);
 		context.refresh();
-		StateMachine<String, String> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<String, String> machine = resolveMachine(context);
 		assertThat(machine, notNullValue());
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S1"));
-		machine.sendEvent("E1");
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S20"));
-		machine.sendEvent("E2");
+		doSendEventAndConsumeAll(machine, "E2");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S30"));
-		machine.sendEvent("E3");
+		doSendEventAndConsumeAll(machine, "E3");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S31"));
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSubmachineRefWithFactory() throws Exception {
 		context.register(Config4.class, Config3.class);
 		context.refresh();
-		StateMachineFactory<String, String> factory = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINEFACTORY, StateMachineFactory.class);
+		StateMachineFactory<String, String> factory = resolveFactory(context);
 		StateMachine<String, String> machine = factory.getStateMachine();
 		assertThat(machine, notNullValue());
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S1"));
-		machine.sendEvent("E1");
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S20"));
-		machine.sendEvent("E2");
+		doSendEventAndConsumeAll(machine, "E2");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S30"));
-		machine.sendEvent("E3");
+		doSendEventAndConsumeAll(machine, "E3");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21", "S31"));
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateChangeInterceptorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateChangeInterceptorTests.java
@@ -18,6 +18,9 @@ package org.springframework.statemachine.support;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -33,7 +36,6 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.access.StateMachineAccess;
 import org.springframework.statemachine.access.StateMachineFunction;
 import org.springframework.statemachine.action.Action;
@@ -57,8 +59,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept() throws InterruptedException {
 		context.register(Config1.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -72,7 +73,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 		});
 
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S1, States.S11));
@@ -80,7 +81,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 
 		listener.reset(3);
 		interceptor.reset(1);
-		machine.sendEvent(Events.C);
+		doSendEventAndConsumeAll(machine, Events.C);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(3));
 		assertThat(interceptor.preStateChangeLatch1.await(2, TimeUnit.SECONDS), is(true));
@@ -88,7 +89,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 		assertThat(interceptor.preStateChangeLatch2.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(interceptor.preStateChangeCount2, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S2, States.S21, States.S211));
-		machine.sendEvent(Events.H);
+		doSendEventAndConsumeAll(machine, Events.H);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0, States.S2, States.S21, States.S211));
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo"), is(1));
 	}
@@ -97,8 +98,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept2() throws InterruptedException {
 		context.register(Config2.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -111,14 +111,14 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1));
@@ -129,7 +129,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.B);
+		doSendEventAndConsumeAll(machine, Events.B);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S2));
@@ -140,7 +140,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.C);
+		doSendEventAndConsumeAll(machine, Events.C);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
@@ -154,8 +154,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept3() throws InterruptedException {
 		context.register(Config3.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -168,14 +167,14 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S2));
@@ -189,8 +188,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept4() throws InterruptedException {
 		context.register(Config4.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -203,14 +201,14 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S2));
@@ -234,8 +232,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept5() throws InterruptedException {
 		context.register(Config4.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -248,14 +245,14 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(MessageBuilder.withPayload(Events.A).setHeader("test", "exists").build());
+		doSendEventAndConsumeAll(machine, MessageBuilder.withPayload(Events.A).setHeader("test", "exists").build());
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S3));
@@ -279,8 +276,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept6() throws InterruptedException {
 		context.register(Config5.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -293,14 +289,14 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S1));
@@ -311,7 +307,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 
 		interceptor.reset(1);
 		listener.reset(1);
-		machine.sendEvent(Events.E);
+		doSendEventAndConsumeAll(machine, Events.E);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S2));
@@ -325,8 +321,7 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 	public void testIntercept7() throws InterruptedException {
 		context.register(Config6.class);
 		context.refresh();
-		@SuppressWarnings("unchecked")
-		StateMachine<States, Events> machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<States, Events> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
 		TestStateChangeInterceptor interceptor = new TestStateChangeInterceptor();
@@ -339,14 +334,14 @@ public class StateChangeInterceptorTests extends AbstractStateMachineTests {
 			}
 		});
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(1));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S0));
 
 		interceptor.reset(2);
 		listener.reset(2);
-		machine.sendEvent(Events.A);
+		doSendEventAndConsumeAll(machine, Events.A);
 		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
 		assertThat(listener.stateChangedCount, is(2));
 		assertThat(machine.getState().getIds(), containsInAnyOrder(States.S2));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/LocalTransitionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/LocalTransitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ package org.springframework.statemachine.transition;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 
@@ -28,7 +29,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
-import org.springframework.statemachine.StateMachineSystemConstants;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.StateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
@@ -36,25 +36,21 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 import org.springframework.statemachine.listener.StateMachineListenerAdapter;
 import org.springframework.statemachine.state.State;
 
-@SuppressWarnings("unchecked")
 public class LocalTransitionTests extends AbstractStateMachineTests {
 
 	@Test
 	public void testExternalSuperDoesEntryExitToSub() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E20");
+		doSendEventAndConsumeAll(machine, "E20");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 		assertThat(listener.exited.size(), is(2));
 		assertThat(listener.entered.size(), is(2));
@@ -66,18 +62,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testLocalSuperDoesNotEntryExitToSub() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E30");
+		doSendEventAndConsumeAll(machine, "E30");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 		assertThat(listener.exited.size(), is(1));
 		assertThat(listener.entered.size(), is(1));
@@ -89,18 +82,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testExternalToNonInitialSuperDoesEntryExitToSub() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E21");
+		doSendEventAndConsumeAll(machine, "E21");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S22"));
 		assertThat(listener.exited.size(), is(2));
 		assertThat(listener.entered.size(), is(2));
@@ -112,18 +102,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testLocalToNonInitialSuperDoesNotEntryExitToSub() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E31");
+		doSendEventAndConsumeAll(machine, "E31");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S22"));
 		assertThat(listener.exited.size(), is(1));
 		assertThat(listener.entered.size(), is(1));
@@ -135,18 +122,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testExternalSuperDoesEntryExitToParent() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E22");
+		doSendEventAndConsumeAll(machine, "E22");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 		assertThat(listener.exited.size(), is(2));
 		assertThat(listener.entered.size(), is(2));
@@ -158,18 +142,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testLocalSuperDoesNotEntryExitToParent() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E32");
+		doSendEventAndConsumeAll(machine, "E32");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 		assertThat(listener.exited.size(), is(1));
 		assertThat(listener.entered.size(), is(1));
@@ -181,18 +162,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testExternalToNonInitialSuperDoesEntryExitToParent() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E21");
+		doSendEventAndConsumeAll(machine, "E21");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S22"));
 		assertThat(listener.exited.size(), is(2));
 		assertThat(listener.entered.size(), is(2));
@@ -200,7 +178,7 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 		assertThat(listener.entered, containsInAnyOrder("S2", "S22"));
 
 		listener.reset();
-		machine.sendEvent("E23");
+		doSendEventAndConsumeAll(machine, "E23");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S22"));
 		assertThat(listener.exited.size(), is(2));
 		assertThat(listener.entered.size(), is(2));
@@ -212,18 +190,15 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 	public void testLocalToNonInitialSuperDoesNotEntryExitToParent() {
 		context.register(Config1.class);
 		context.refresh();
-		assertTrue(context.containsBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE));
-		StateMachine<String, String> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
-		assertThat(machine, notNullValue());
+		StateMachine<String, String> machine = resolveMachine(context);
 		TestListener listener = new TestListener();
 		machine.addStateListener(listener);
-		machine.start();
-		machine.sendEvent("E1");
+		doStartAndAssert(machine);
+		doSendEventAndConsumeAll(machine, "E1");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S21"));
 
 		listener.reset();
-		machine.sendEvent("E31");
+		doSendEventAndConsumeAll(machine, "E31");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S22"));
 		assertThat(listener.exited.size(), is(1));
 		assertThat(listener.entered.size(), is(1));
@@ -231,7 +206,7 @@ public class LocalTransitionTests extends AbstractStateMachineTests {
 		assertThat(listener.entered, containsInAnyOrder("S22"));
 
 		listener.reset();
-		machine.sendEvent("E33");
+		doSendEventAndConsumeAll(machine, "E33");
 		assertThat(machine.getState().getIds(), containsInAnyOrder("S2", "S22"));
 		assertThat(listener.exited.size(), is(1));
 		assertThat(listener.entered.size(), is(1));

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionOrderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionOrderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package org.springframework.statemachine.transition;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -28,7 +31,6 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.StateMachine;
@@ -54,161 +56,143 @@ public class TransitionOrderTests extends AbstractStateMachineTests {
 		return new AnnotationConfigApplicationContext();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent1() {
 		TestListener listener = new TestListener();
 		context.register(Config1.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 		assertThat(listener.statesEntered, contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered, contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent2() {
 		TestListener listener = new TestListener();
 		context.register(Config2.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered, contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseChild1() {
 		TestListener listener = new TestListener();
 		context.register(Config3.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered, contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1012, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent3() {
 		TestListener listener = new TestListener();
 		context.register(Config4.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered, contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent4() {
 		TestListener listener = new TestListener();
 		context.register(Config5.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered, contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1012));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent5() {
 		TestListener listener = new TestListener();
 		context.register(Config6.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered, contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent6() {
 		TestListener listener = new TestListener();
 		context.register(Config7.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered,
 				contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1012, TestStates.S2011, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent7() {
 		TestListener listener = new TestListener();
 		context.register(Config8.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEntered,
 				contains(TestStates.S1, TestStates.S10, TestStates.S1011, TestStates.S1));
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testAnonymousTransitionInConfigUseParent3Threading() throws InterruptedException {
 		TestListener listener = new TestListener();
 		context.register(Config4.class, StateMachineExecutorConfiguration.class);
 		context.refresh();
-		StateMachine<TestStates,TestEvents> machine =
-				context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, StateMachine.class);
+		StateMachine<TestStates, TestEvents> machine = resolveMachine(context);
 		machine.addStateListener(listener);
 
-		machine.start();
+		doStartAndAssert(machine);
 		assertThat(listener.statesEnteredLatch.await(1, TimeUnit.SECONDS), is(true));
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 
 		listener.reset(1, 3);
-		machine.sendEvent(MessageBuilder.withPayload(TestEvents.E1).build());
+		doSendEventAndConsumeAll(machine, TestEvents.E1);
 		assertThat(listener.statesEnteredLatch.await(1, TimeUnit.SECONDS), is(true));
 		assertThat(listener.statesEntered, contains(TestStates.S10, TestStates.S1011, TestStates.S1));
 	}

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateContextAssert.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateContextAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.assertj;
+package org.springframework.statemachine.test.assertj;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.util.Objects;
@@ -55,7 +55,7 @@ public class StateContextAssert extends AbstractAssert<StateContextAssert, State
 	/**
 	 * Verifies that the actual context has the same {@code event} as given {@code event}.
 	 *
-	 * @param stage the expected stage
+	 * @param event the expected event
 	 * @return {@code this} assertion object.
 	 * @throws AssertionError if the stage of the actual context is not equal to the given one.
 	 */

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateMachineAssert.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateMachineAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.assertj;
+package org.springframework.statemachine.test.assertj;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.util.Objects;

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateMachineAsserts.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateMachineAsserts.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.assertj;
+package org.springframework.statemachine.test.assertj;
 
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateMachineEventResultAssert.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/assertj/StateMachineEventResultAssert.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.assertj;
+package org.springframework.statemachine.test.assertj;
 
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.util.Objects;

--- a/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/assertj/StateMachineEventResultAssertTests.java
+++ b/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/assertj/StateMachineEventResultAssertTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.assertj;
+package org.springframework.statemachine.test.assertj;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -39,4 +39,3 @@ public class StateMachineEventResultAssertTests {
 			.withMessageContaining("Expected result's type to be <DENIED> but was <ACCEPTED>");
 	}
 }
-


### PR DESCRIPTION
- Remove use of statemachine assertj assertions to prepare move
- Move statemachine assertj assertion to spring-statemachine-test
- Polish some tests and user TestUtils from core tests
- Remove most of a deprecation warning from core tests
- Relates #744