### PR TITLE
Fix use of deprected method in MongoDbRule

### DIFF
--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/tck/mongodb/MongoDbRule.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/tck/mongodb/MongoDbRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,11 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.ServerAddress;
+import org.springframework.util.SocketUtils;
 
 /**
- * Rule skipping tests if MongoDb is not available from localhost with default settings.
+ * Rule skipping tests if MongoDb is not available from localhost simply by
+ * checking if port can be bind.
  *
  * @author Janne Valkealahti
  *
@@ -33,22 +32,16 @@ public class MongoDbRule extends TestWatcher implements TestRule {
 
 	@Override
 	public Statement apply(Statement base, Description description) {
-		MongoClient client = null;
+
 		try {
-			client = new MongoClient(new ServerAddress(),
-					MongoClientOptions.builder().connectTimeout(50).serverSelectionTimeout(50).build());
-			client.getAddress();
-		} catch (Exception e) {
+			SocketUtils.findAvailableTcpPort(27017, 27017);
 			return super.apply(new Statement() {
 				@Override
 				public void evaluate() throws Throwable {
 				}
 			}, Description.EMPTY);
-		} finally {
-			if (client != null) {
-				client.close();
-			}
+		} catch (Exception e) {
+			return super.apply(base, description);
 		}
-		return super.apply(base, description);
 	}
 }

--- a/spring-statemachine-data/mongodb/src/test/java/org/springframework/statemachine/data/mongodb/MongoDbRule.java
+++ b/spring-statemachine-data/mongodb/src/test/java/org/springframework/statemachine/data/mongodb/MongoDbRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,11 @@ import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.ServerAddress;
+import org.springframework.util.SocketUtils;
 
 /**
- * Rule skipping tests if MongoDb is not available from localhost with default settings.
+ * Rule skipping tests if MongoDb is not available from localhost simply by
+ * checking if port can be bind.
  *
  * @author Janne Valkealahti
  *
@@ -33,22 +32,16 @@ public class MongoDbRule extends TestWatcher implements TestRule {
 
 	@Override
 	public Statement apply(Statement base, Description description) {
-		MongoClient client = null;
+
 		try {
-			client = new MongoClient(new ServerAddress(),
-					MongoClientOptions.builder().connectTimeout(50).serverSelectionTimeout(50).build());
-			client.getAddress();
-		} catch (Exception e) {
+			SocketUtils.findAvailableTcpPort(27017, 27017);
 			return super.apply(new Statement() {
 				@Override
 				public void evaluate() throws Throwable {
 				}
 			}, Description.EMPTY);
-		} finally {
-			if (client != null) {
-				client.close();
-			}
+		} catch (Exception e) {
+			return super.apply(base, description);
 		}
-		return super.apply(base, description);
 	}
 }


### PR DESCRIPTION
- Switch to use a simple port check instead of trying
  to actually connect via mongo client.
- Relates #397