### PR TITLE
Reactive changes for StateMachineTestPlan

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,8 @@ project('spring-statemachine-test') {
 		testCompile("org.mockito:mockito-core") { dep ->
 			exclude group: "org.hamcrest"
 		}
+		testCompile project(path:":spring-statemachine-core", configuration:"testArtifacts")
+		testCompile "io.projectreactor:reactor-test"
 	}
 }
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/DistributedLeaderActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/DistributedLeaderActionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package org.springframework.statemachine.action;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.resolveFactory;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -51,17 +53,17 @@ public class DistributedLeaderActionTests extends AbstractStateMachineTests {
 
 		TestLeaderAction action = context.getBean("testLeaderAction", TestLeaderAction.class);
 
-		@SuppressWarnings("unchecked")
-		StateMachineFactory<String, String> factory = context.getBean(StateMachineFactory.class);
+		StateMachineFactory<String, String> factory = resolveFactory(context);
 
 		StateMachine<String, String> machine1 = factory.getStateMachine();
 		StateMachine<String, String> machine2 = factory.getStateMachine();
-		machine1.sendEvent("E1");
+
+		doSendEventAndConsumeAll(machine1, "E1");
 		assertThat(action.latch.await(1, TimeUnit.SECONDS), is(false));
 		assertThat(action.count, is(1));
 		action.reset(2);
 
-		machine2.sendEvent("E2");
+		doSendEventAndConsumeAll(machine2, "E2");
 		assertThat(action.latch.await(1, TimeUnit.SECONDS), is(false));
 		assertThat(action.count, is(1));
 	}
@@ -129,6 +131,7 @@ public class DistributedLeaderActionTests extends AbstractStateMachineTests {
 
 		@Override
 		public void execute(StateContext<String, String> context) {
+			System.out.println("XXX " + context);
 			count++;
 			latch.countDown();
 		}

--- a/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/StateMachineTestingTests.java
+++ b/spring-statemachine-test/src/test/java/org/springframework/statemachine/test/StateMachineTestingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.springframework.statemachine.test;
 
 import static org.hamcrest.CoreMatchers.not;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import org.hamcrest.collection.IsMapContaining;
 import org.junit.Test;
@@ -33,11 +34,10 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 
 public class StateMachineTestingTests extends AbstractStateMachineTests {
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testSimpleTestingConcept() throws Exception {
 		registerAndRefresh(Config1.class);
-		StateMachine<String, String> machine =	context.getBean(StateMachine.class);
+		StateMachine<String, String> machine =	resolveMachine(context);
 
 		StateMachineTestPlan<String, String> plan =
 				StateMachineTestPlanBuilder.<String, String>builder()
@@ -50,11 +50,10 @@ public class StateMachineTestingTests extends AbstractStateMachineTests {
 		plan.test();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testStarted() throws Exception {
 		registerAndRefresh(Config2.class);
-		StateMachine<String, String> machine =	context.getBean(StateMachine.class);
+		StateMachine<String, String> machine =	resolveMachine(context);
 
 		StateMachineTestPlan<String, String> plan =
 				StateMachineTestPlanBuilder.<String, String>builder()
@@ -68,11 +67,10 @@ public class StateMachineTestingTests extends AbstractStateMachineTests {
 		plan.test();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testMultipleEvents() throws Exception {
 		registerAndRefresh(Config3.class);
-		StateMachine<String, String> machine =	context.getBean(StateMachine.class);
+		StateMachine<String, String> machine =	resolveMachine(context);
 
 		StateMachineTestPlan<String, String> plan =
 				StateMachineTestPlanBuilder.<String, String>builder()
@@ -90,11 +88,10 @@ public class StateMachineTestingTests extends AbstractStateMachineTests {
 		plan.test();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testIntermediate() throws Exception {
 		registerAndRefresh(Config4.class);
-		StateMachine<String, String> machine =	context.getBean(StateMachine.class);
+		StateMachine<String, String> machine =	resolveMachine(context);
 
 		StateMachineTestPlan<String, String> plan =
 				StateMachineTestPlanBuilder.<String, String>builder()
@@ -108,11 +105,10 @@ public class StateMachineTestingTests extends AbstractStateMachineTests {
 		plan.test();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testVariables() throws Exception {
 		registerAndRefresh(Config5.class);
-		StateMachine<String, String> machine =	context.getBean(StateMachine.class);
+		StateMachine<String, String> machine =	resolveMachine(context);
 
 		StateMachineTestPlan<String, String> plan =
 				StateMachineTestPlanBuilder.<String, String>builder()


### PR DESCRIPTION
- Move to use reactive methods and for now block
  as concept is really blocking. Full reactive stuff
  needs bigger overhaul.
- Fix event issues in DistributedStateMachine as these
  caused issues when StateMachineTestPlan were changed to
  send events via reactive methods.
- Relates #744
- Relates #750