### PR TITLE
Relax sync in DefaultStateMachineService

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/service/DefaultStateMachineService.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/service/DefaultStateMachineService.java
@@ -84,8 +84,10 @@ public class DefaultStateMachineService<S, E> implements StateMachineService<S, 
 	@Override
 	public StateMachine<S, E> acquireStateMachine(String machineId, boolean start) {
 		log.info("Acquiring machine with id " + machineId);
+		StateMachine<S, E> stateMachine;
+		// naive sync to handle concurrency with release
 		synchronized (machines) {
-			StateMachine<S,E> stateMachine = machines.get(machineId);
+			stateMachine = machines.get(machineId);
 			if (stateMachine == null) {
 				log.info("Getting new machine from factory with id " + machineId);
 				stateMachine = stateMachineFactory.getStateMachine(machineId);
@@ -100,8 +102,9 @@ public class DefaultStateMachineService<S, E> implements StateMachineService<S, 
 				}
 				machines.put(machineId, stateMachine);
 			}
-			return handleStart(stateMachine, start);
 		}
+		// handle start outside of sync as it might take some time and would block other machines acquire
+		return handleStart(stateMachine, start);
 	}
 
 	@Override


### PR DESCRIPTION
- Now starting machine outside of a sycn block with
  acquire vs. release. This should allow long running
  start in a machine to allow next acquire to work faster.
- Fixes #754