### PR TITLE
Refactor to junit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,6 @@ configure(subprojects) { subproject ->
 	dependencies {
 		testCompile("org.junit.jupiter:junit-jupiter-api")
 		testRuntime("org.junit.jupiter:junit-jupiter-engine")
-		testRuntime("org.junit.vintage:junit-vintage-engine")
 		if (project.hasProperty('statemachineBlockHound') && statemachineBlockHound.toBoolean()) {
 			testRuntime("org.junit.platform:junit-platform-launcher")
 			testRuntime("io.projectreactor.tools:blockhound-junit-platform")
@@ -210,7 +209,8 @@ project('spring-statemachine-core') {
 		testCompile('org.mockito:mockito-core') { dep ->
 			exclude group: 'org.hamcrest'
 		}
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 		testCompile 'org.assertj:assertj-core'
 		testCompile 'org.springframework.security:spring-security-config'
 		testCompile 'org.springframework.security:spring-security-test'
@@ -251,7 +251,8 @@ project('spring-statemachine-autoconfigure') {
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 	}
 }
 
@@ -265,6 +266,8 @@ project('spring-statemachine-test') {
 		compile 'org.hamcrest:hamcrest-core'
 		compile 'org.hamcrest:hamcrest-library'
 		compile 'junit:junit'
+		compile 'org.junit.jupiter:junit-jupiter-api'
+		compile 'org.junit.vintage:junit-vintage-engine'
 		compile 'org.assertj:assertj-core'
 		testCompile('org.mockito:mockito-core') { dep ->
 			exclude group: 'org.hamcrest'
@@ -281,11 +284,15 @@ project('spring-statemachine-kryo') {
 		compile project(':spring-statemachine-core')
 		compile 'com.esotericsoftware:kryo-shaded'
 
-		testCompile project(':spring-statemachine-test')
+		testCompile (project(':spring-statemachine-test')) { dep ->
+			exclude group: 'junit', module: 'junit'
+			exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+		}
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 		testRuntime 'org.apache.logging.log4j:log4j-core'
 	}
 }
@@ -301,12 +308,16 @@ project('spring-statemachine-zookeeper') {
 		// github.com/spring-gradle-plugins/dependency-management-plugin/issues/136
 		runtime 'log4j:log4j'
 
-		testCompile project(':spring-statemachine-test')
+		testCompile (project(':spring-statemachine-test')) { dep ->
+			exclude group: 'junit', module: 'junit'
+			exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+		}
 		testCompile 'org.apache.curator:curator-test'
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 		testRuntime 'org.apache.logging.log4j:log4j-core'
 	}
 }
@@ -322,7 +333,10 @@ project('spring-statemachine-data-common') {
 		optional 'org.springframework.security:spring-security-core'
 		compile 'com.fasterxml.jackson.core:jackson-core'
 		compile 'com.fasterxml.jackson.core:jackson-databind'
-		testCompile project(':spring-statemachine-test')
+		testCompile (project(':spring-statemachine-test')) { dep ->
+			exclude group: 'junit', module: 'junit'
+			exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+		}
 		testCompile project(path:':spring-statemachine-core', configuration:'testArtifacts')
 		testCompile 'io.projectreactor:reactor-test'
 		testCompile 'org.springframework.boot:spring-boot-starter-test'
@@ -344,12 +358,16 @@ project('spring-statemachine-cluster') {
 		compile project(':spring-statemachine-zookeeper')
 		compile 'org.springframework.integration:spring-integration-zookeeper'
 
-		testCompile project(':spring-statemachine-test')
+		testCompile (project(':spring-statemachine-test')) { dep ->
+			exclude group: 'junit', module: 'junit'
+			exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+		}
 		testCompile 'org.apache.curator:curator-test'
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 		testRuntime 'org.apache.logging.log4j:log4j-core'
 	}
 }
@@ -387,7 +405,8 @@ project('spring-statemachine-uml') {
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 		testCompile 'org.awaitility:awaitility'
 		testRuntime 'org.apache.logging.log4j:log4j-core'
 	}
@@ -415,7 +434,6 @@ project('spring-statemachine-build-tests') {
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
 	}
 }
 
@@ -427,7 +445,8 @@ configure(recipeProjects()) {
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 	}
 }
 
@@ -440,7 +459,8 @@ project('spring-statemachine-recipes-common') {
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 	}
 }
 
@@ -526,12 +546,16 @@ configure(sampleProjects()) {
 		testCompile('org.mockito:mockito-core') { dep ->
 			exclude group: 'org.hamcrest'
 		}
-		testCompile project(':spring-statemachine-test')
+		testCompile (project(':spring-statemachine-test')) { dep ->
+			exclude group: 'junit', module: 'junit'
+			exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+		}
 		testCompile 'org.springframework.boot:spring-boot-test'
 		testCompile 'org.springframework:spring-test'
 		testCompile 'org.hamcrest:hamcrest-core'
 		testCompile 'org.hamcrest:hamcrest-library'
-		testCompile 'junit:junit'
+		testCompile("org.junit.jupiter:junit-jupiter-api")
+		testCompile("org.junit.jupiter:junit-jupiter-engine")
 	}
 	bootJar {
 		excludeDevtools = false

--- a/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineAutoConfigurationTests.java
+++ b/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineAutoConfigurationTests.java
@@ -18,12 +18,12 @@ package org.springframework.statemachine.boot;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -46,7 +46,7 @@ public class StateMachineAutoConfigurationTests {
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void close() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineJpaRepositoriesAutoConfigurationTests.java
+++ b/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineJpaRepositoriesAutoConfigurationTests.java
@@ -16,10 +16,10 @@
 package org.springframework.statemachine.boot;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.EmbeddedDataSourceConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
@@ -33,7 +33,7 @@ public class StateMachineJpaRepositoriesAutoConfigurationTests {
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void close() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineMongoDbRepositoriesAutoConfigurationTests.java
+++ b/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineMongoDbRepositoriesAutoConfigurationTests.java
@@ -16,10 +16,10 @@
 package org.springframework.statemachine.boot;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.mongo.MongoRepositoriesAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
@@ -34,7 +34,7 @@ public class StateMachineMongoDbRepositoriesAutoConfigurationTests {
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void close() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineRedisRepositoriesAutoConfigurationTests.java
+++ b/spring-statemachine-autoconfigure/src/test/java/org/springframework/statemachine/boot/StateMachineRedisRepositoriesAutoConfigurationTests.java
@@ -16,10 +16,10 @@
 package org.springframework.statemachine.boot;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
 import org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -32,7 +32,7 @@ public class StateMachineRedisRepositoriesAutoConfigurationTests {
 
 	private AnnotationConfigApplicationContext context;
 
-	@After
+	@AfterEach
 	public void close() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-cluster/src/test/java/org/springframework/statemachine/cluster/AbstractZookeeperTests.java
+++ b/spring-statemachine-cluster/src/test/java/org/springframework/statemachine/cluster/AbstractZookeeperTests.java
@@ -21,8 +21,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -33,12 +33,12 @@ public abstract class AbstractZookeeperTests {
 
 	protected AnnotationConfigApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = buildContext();
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-cluster/src/test/java/org/springframework/statemachine/cluster/LeaderZookeeperStateMachineEnsembleTests.java
+++ b/spring-statemachine-cluster/src/test/java/org/springframework/statemachine/cluster/LeaderZookeeperStateMachineEnsembleTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.cluster;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/AbstractStateMachineTests.java
@@ -22,8 +22,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -49,12 +49,12 @@ public abstract class AbstractStateMachineTests {
 
 	protected AnnotationConfigApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = buildContext();
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/EnumStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/EnumStateMachineTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,7 +24,7 @@ import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.task.SyncTaskExecutor;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventDeferTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventDeferTests.java
@@ -18,8 +18,8 @@ package org.springframework.statemachine;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventHeaderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventHeaderTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -25,7 +25,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/ReactiveTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/ReactiveTests.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/RegionMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/RegionMachineTests.java
@@ -16,20 +16,20 @@
 package org.springframework.statemachine;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/RelayTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/RelayTests.java
@@ -16,16 +16,16 @@
 package org.springframework.statemachine;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateContextTests.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineErrorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineErrorTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.statemachine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineFactoryTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineFactoryTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveFactory;
@@ -26,7 +26,7 @@ import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.statemachine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.statemachine;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/SubStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/SubStateMachineTests.java
@@ -16,10 +16,10 @@
 package org.springframework.statemachine;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/access/StateMachineAccessTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/access/StateMachineAccessTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.access;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
 import org.springframework.statemachine.ExtendedState;
 import org.springframework.statemachine.StateMachine;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionAndTimerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionAndTimerTests.java
@@ -16,9 +16,9 @@
 package org.springframework.statemachine.action;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -26,7 +26,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionErrorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionErrorTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.statemachine.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ActionTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.statemachine.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -26,7 +26,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/DistributedLeaderActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/DistributedLeaderActionTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.resolveFactory;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ReactiveActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/ReactiveActionTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -24,7 +24,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/SpelExpressionActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/SpelExpressionActionTests.java
@@ -16,15 +16,15 @@
 package org.springframework.statemachine.action;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/StateDoActivityActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/action/StateDoActivityActionTests.java
@@ -15,16 +15,16 @@
  */
 package org.springframework.statemachine.action;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/ClassAnnotationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/ClassAnnotationTests.java
@@ -16,7 +16,7 @@
 package org.springframework.statemachine.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -25,15 +25,13 @@ import java.lang.annotation.Target;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.statemachine.AbstractStateMachineTests;
 import org.springframework.statemachine.ObjectStateMachine;
-import org.springframework.statemachine.annotation.OnTransition;
-import org.springframework.statemachine.annotation.WithStateMachine;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationTests.java
@@ -17,15 +17,15 @@ package org.springframework.statemachine.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithBuilderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithBuilderTests.java
@@ -16,8 +16,8 @@
 package org.springframework.statemachine.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -26,7 +26,7 @@ import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithFactoryTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/annotation/MethodAnnotationWithFactoryTests.java
@@ -16,8 +16,8 @@
 package org.springframework.statemachine.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveFactory;
@@ -26,7 +26,7 @@ import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ConfigurationErrorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ConfigurationErrorTests.java
@@ -15,16 +15,17 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;
@@ -37,52 +38,55 @@ import org.springframework.statemachine.config.model.verifier.StateMachineModelV
 
 public class ConfigurationErrorTests extends AbstractStateMachineTests {
 
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
+    @Override
+    protected AnnotationConfigApplicationContext buildContext() {
+        return new AnnotationConfigApplicationContext();
+    }
 
-	@Override
-	protected AnnotationConfigApplicationContext buildContext() {
-		return new AnnotationConfigApplicationContext();
-	}
+    @Test
+    public void testInitialStateNotSet1() {
+        Exception exception = assertThrows(Exception.class, ()-> {
+            context.register(Config1.class);
+            context.refresh();
+        });
+        assertTrue(exception.getCause() instanceof MalformedConfigurationException);
+    }
 
-	@Test
-	public void testInitialStateNotSet1() {
-		expectedException.expectCause(isA(MalformedConfigurationException.class));
-		context.register(Config1.class);
-		context.refresh();
-	}
+    @Test
+    public void testInitialStateNotSet2() throws Exception {
+        Exception exception = assertThrows(Exception.class, ()-> {
+            Builder<String, String> builder = StateMachineBuilder.builder();
+            builder
+                .configureStates()
+                .withStates()
+                .state("S1")
+                .state("S2");
+            builder
+                .configureTransitions()
+                .withExternal()
+                .source("S1")
+                .target("S2")
+                .event("E1");
 
-	@Test
-	public void testInitialStateNotSet2() throws Exception {
-		expectedException.expectCause(isA(MalformedConfigurationException.class));
-		Builder<String, String> builder = StateMachineBuilder.builder();
-		builder
-			.configureStates()
-				.withStates()
-					.state("S1")
-					.state("S2");
-		builder
-			.configureTransitions()
-				.withExternal()
-					.source("S1")
-					.target("S2")
-					.event("E1");
+            builder.build();
+        });
+        assertTrue(exception.getCause() instanceof MalformedConfigurationException);
+    }
 
-		builder.build();
-	}
-
-	@Test
-	public void testNoTransitions() throws Exception {
-		expectedException.expectCause(isA(MalformedConfigurationException.class));
-		Builder<String, String> builder = StateMachineBuilder.builder();
-		builder
-			.configureStates()
-				.withStates()
-					.initial("S1")
-					.state("S1")
-					.state("S2");
-		builder.build();
-	}
+    @Test
+    public void testNoTransitions() throws Exception {
+        Exception exception = assertThrows(Exception.class, ()-> {
+            Builder<String, String> builder = StateMachineBuilder.builder();
+            builder
+                .configureStates()
+                .withStates()
+                .initial("S1")
+                .state("S1")
+                .state("S2");
+            builder.build();
+        });
+        assertTrue(exception.getCause() instanceof MalformedConfigurationException);
+    }
 
 	@Test
 	public void testVerifierDisabled() throws Exception {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ConfigurationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ConfigurationTests.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,7 +29,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -167,10 +168,12 @@ public class ConfigurationTests extends AbstractStateMachineTests {
 		context.refresh();
 	}
 
-	@Test(expected = BeanCreationException.class)
+	@Test
 	public void testEnableStateMachineFactoryNoAdapter() {
-		context.register(Config13.class);
-		context.refresh();
+		assertThrows(BeanCreationException.class, () -> {
+			context.register(Config13.class);
+			context.refresh();
+		});
 	}
 
 	@Test
@@ -955,7 +958,8 @@ public class ConfigurationTests extends AbstractStateMachineTests {
 					.event("E1");
 		}
 	}
-	
+
+
 	@Configuration
 	@EnableStateMachineFactory(name="stateMachineConfig22")
 	public static class Config22 extends StateMachineConfigurerAdapter<String, String> {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ContextTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/MachineTypedTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/MachineTypedTests.java
@@ -17,10 +17,10 @@ package org.springframework.statemachine.config;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderContextTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -25,7 +25,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/ManualBuilderTests.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.support.StaticListableBeanFactory;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.task.SyncTaskExecutor;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/SessionScopedAnnotationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/SessionScopedAnnotationTests.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -57,7 +58,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import reactor.core.publisher.Mono;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes={SessionScopedAnnotationTests.Config2.class, SessionScopedAnnotationTests.Config1.class})
 @WebAppConfiguration
 @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
@@ -68,7 +69,7 @@ public class SessionScopedAnnotationTests {
 
 	private MockMvc mvc;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/SessionScopedManualTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/SessionScopedManualTests.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.statemachine.config;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -56,7 +57,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import reactor.core.publisher.Mono;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @WebAppConfiguration
 @DirtiesContext(methodMode = MethodMode.AFTER_METHOD)
@@ -67,7 +68,7 @@ public class SessionScopedManualTests {
 
 	private MockMvc mvc;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/ComplexAnnotationConfigurationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/ComplexAnnotationConfigurationTests.java
@@ -17,14 +17,15 @@ package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 import java.util.Iterator;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +38,7 @@ import org.springframework.statemachine.config.common.annotation.complex.Complex
 import org.springframework.statemachine.config.common.annotation.complex.ComplexTestConfigurerAdapter;
 import org.springframework.statemachine.config.common.annotation.complex.EnableComplexTest;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
 /**
@@ -46,7 +47,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
  * @author Janne Valkealahti
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(loader=AnnotationConfigContextLoader.class)
 public class ComplexAnnotationConfigurationTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/ImportingBeanDefinitionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/ImportingBeanDefinitionTests.java
@@ -16,11 +16,11 @@
 package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/MixedAnnotationConfigurationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/MixedAnnotationConfigurationTests.java
@@ -17,12 +17,12 @@ package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -35,10 +35,11 @@ import org.springframework.statemachine.config.common.annotation.simple.SimpleTe
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigBuilder;
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigurerAdapter;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(loader=AnnotationConfigContextLoader.class)
 public class MixedAnnotationConfigurationTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/MultipleAnnotationConfigurationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/MultipleAnnotationConfigurationTests.java
@@ -17,12 +17,12 @@ package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -35,10 +35,10 @@ import org.springframework.statemachine.config.common.annotation.simple.SimpleTe
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigBuilder;
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigurerAdapter;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(loader=AnnotationConfigContextLoader.class)
 public class MultipleAnnotationConfigurationTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/SimpleAnnotationConfiguration2Tests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/SimpleAnnotationConfiguration2Tests.java
@@ -17,14 +17,14 @@ package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -36,6 +36,7 @@ import org.springframework.statemachine.config.common.annotation.simple.SimpleTe
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigBuilder;
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigurerAdapter;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
@@ -45,7 +46,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
  * @author Janne Valkealahti
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(loader=AnnotationConfigContextLoader.class)
 public class SimpleAnnotationConfiguration2Tests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/SimpleAnnotationConfigurationTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/SimpleAnnotationConfigurationTests.java
@@ -17,14 +17,14 @@ package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -37,6 +37,7 @@ import org.springframework.statemachine.config.common.annotation.simple.SimpleTe
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigBuilder;
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigurerAdapter;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
@@ -46,7 +47,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
  * @author Janne Valkealahti
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(loader=AnnotationConfigContextLoader.class)
 public class SimpleAnnotationConfigurationTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/XmlImportDependenciesTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/common/annotation/XmlImportDependenciesTests.java
@@ -16,12 +16,12 @@
 package org.springframework.statemachine.config.common.annotation;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +32,7 @@ import org.springframework.statemachine.config.common.annotation.simple.SimpleTe
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigBuilder;
 import org.springframework.statemachine.config.common.annotation.simple.SimpleTestConfigurerAdapter;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 
@@ -42,7 +43,7 @@ import org.springframework.test.context.support.AnnotationConfigContextLoader;
  * @author Janne Valkealahti
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(loader=AnnotationConfigContextLoader.class)
 public class XmlImportDependenciesTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/configurers/DefaultStateConfigurerTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.config.configurers;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.AbstractStateMachineTests.TestEntryAction;
 import org.springframework.statemachine.AbstractStateMachineTests.TestEvents;
 import org.springframework.statemachine.AbstractStateMachineTests.TestExitAction;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelFactoryTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelFactoryTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.config.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
@@ -29,7 +29,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.config.model;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
@@ -27,7 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests10.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests10.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.statemachine.docs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests2.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests2.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.docs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -24,7 +24,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests5.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests5.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.statemachine.docs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.support.MessageBuilder;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests6.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/DocsConfigurationSampleTests6.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.docs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.config.ObjectStateMachineFactory;
 import org.springframework.statemachine.config.model.ConfigurationData;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/IntroSample.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/docs/IntroSample.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.statemachine.docs;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.EnumSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.support.MessageBuilder;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/ensemble/DistributedStateMachineTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/ensemble/DistributedStateMachineTests.java
@@ -16,9 +16,9 @@
 package org.springframework.statemachine.ensemble;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/event/ContextEventTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/event/ContextEventTests.java
@@ -16,13 +16,13 @@
 package org.springframework.statemachine.event;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/event/StateMachineEventTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/event/StateMachineEventTests.java
@@ -17,17 +17,17 @@ package org.springframework.statemachine.event;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/guard/GuardTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/guard/GuardTests.java
@@ -16,13 +16,13 @@
 package org.springframework.statemachine.guard;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/guard/SpelExpressionGuardTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/guard/SpelExpressionGuardTests.java
@@ -16,15 +16,15 @@
 package org.springframework.statemachine.guard;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.expression.Expression;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/listener/CompositeStateMachineListenerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/listener/CompositeStateMachineListenerTests.java
@@ -15,35 +15,35 @@
  */
 package org.springframework.statemachine.listener;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
+import org.springframework.statemachine.TestUtils;
 
 import java.util.List;
 
-import org.junit.Test;
-import org.springframework.statemachine.TestUtils;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class CompositeStateMachineListenerTests {
 
-	@Test
-	public void testRegister() throws Exception {
-		CompositeStateMachineListener<String, String> listener = new CompositeStateMachineListener<String, String>();
-		StateMachineListenerAdapter<String, String> adapter1 = new StateMachineListenerAdapter<String, String>();
-		listener.register(adapter1);
-		OrderedComposite<StateMachineListener<String, String>> listeners = listener.getListeners();
-		List<Object> list = TestUtils.readField("list", listeners);
-		assertThat(list.size(), is(1));
-	}
+    @Test
+    public void testRegister() throws Exception {
+        CompositeStateMachineListener<String, String> listener = new CompositeStateMachineListener<String, String>();
+        StateMachineListenerAdapter<String, String> adapter1 = new StateMachineListenerAdapter<String, String>();
+        listener.register(adapter1);
+        OrderedComposite<StateMachineListener<String, String>> listeners = listener.getListeners();
+        List<Object> list = TestUtils.readField("list", listeners);
+        assertThat(list.size(), is(1));
+    }
 
-	@Test
-	public void testUnregister() throws Exception {
-		CompositeStateMachineListener<String, String> listener = new CompositeStateMachineListener<String, String>();
-		StateMachineListenerAdapter<String, String> adapter1 = new StateMachineListenerAdapter<String, String>();
-		listener.register(adapter1);
-		listener.unregister(adapter1);
-		OrderedComposite<StateMachineListener<String, String>> listeners = listener.getListeners();
-		List<Object> list = TestUtils.readField("list", listeners);
-		assertThat(list.size(), is(0));
-	}
+    @Test
+    public void testUnregister() throws Exception {
+        CompositeStateMachineListener<String, String> listener = new CompositeStateMachineListener<String, String>();
+        StateMachineListenerAdapter<String, String> adapter1 = new StateMachineListenerAdapter<String, String>();
+        listener.register(adapter1);
+        listener.unregister(adapter1);
+        OrderedComposite<StateMachineListener<String, String>> listeners = listener.getListeners();
+        List<Object> list = TestUtils.readField("list", listeners);
+        assertThat(list.size(), is(0));
+    }
 
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/listener/ListenerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/listener/ListenerTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.statemachine.listener;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/monitor/StateMachineMonitorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/monitor/StateMachineMonitorTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.monitor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -28,7 +28,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/DefaultStateMachinePersisterTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/DefaultStateMachinePersisterTests.java
@@ -18,13 +18,13 @@ package org.springframework.statemachine.persist;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.StateMachinePersist;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.statemachine.persist;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveFactory;
@@ -27,7 +27,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests2.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests2.java
@@ -24,7 +24,7 @@ import static org.springframework.statemachine.TestUtils.resolveFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests3.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests3.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.statemachine.persist;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests4.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/persist/StateMachinePersistTests4.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.statemachine.persist;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveFactory;
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/processor/AnnotatedMethodTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/processor/AnnotatedMethodTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.processor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,7 +27,7 @@ import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/processor/MethodParameterTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/processor/MethodParameterTests.java
@@ -16,13 +16,13 @@
 package org.springframework.statemachine.processor;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/processor/StateMachineAnnotationPostProcessorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/processor/StateMachineAnnotationPostProcessorTests.java
@@ -16,12 +16,12 @@
 package org.springframework.statemachine.processor;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/AbstractSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/AbstractSecurityTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 
 import java.util.concurrent.CountDownLatch;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/ActionSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/ActionSecurityTests.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.statemachine.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,15 +52,15 @@ import org.springframework.statemachine.state.State;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests for securing actions.
  *
  * @author Janne Valkealahti
  */
-@Ignore("TODO: REACTOR rethink security things")
-@RunWith(SpringJUnit4ClassRunner.class)
+@Disabled("TODO: REACTOR rethink security things")
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {Config1.class, Config2.class})
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class ActionSecurityTests extends AbstractStateMachineTests {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/EventSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/EventSecurityTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.security;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.statemachine.StateMachine;
@@ -24,46 +24,46 @@ import org.springframework.statemachine.security.SecurityRule.ComparisonType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class EventSecurityTests extends AbstractSecurityTests {
 
-	@Test
-	public void testNoSecurityContext() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    public void testNoSecurityContext() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Test
-	@WithMockUser(roles = { "ANONYMOUS" })
-	public void testEventDeniedViaExpression() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, null, null, null, null, null, "false");
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    @WithMockUser(roles = {"ANONYMOUS"})
+    public void testEventDeniedViaExpression() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, null, null, null, null, null, "false");
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Test
-	@WithMockUser(roles = { "ANONYMOUS" })
-	public void testEventDeniedViaAttributes() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, null, null, null, "EVENT_B", ComparisonType.ALL, null);
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    @WithMockUser(roles = {"ANONYMOUS"})
+    public void testEventDeniedViaAttributes() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, null, null, null, "EVENT_B", ComparisonType.ALL, null);
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Test
-	@WithMockUser(roles = { "ANONYMOUS" })
-	public void testEventAllowedViaAttributes() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, null, null, null, "EVENT_A", ComparisonType.ALL, null);
-		assertTransitionAllowed(machine, listener);
-	}
+    @Test
+    @WithMockUser(roles = {"ANONYMOUS"})
+    public void testEventAllowedViaAttributes() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, null, null, null, "EVENT_A", ComparisonType.ALL, null);
+        assertTransitionAllowed(machine, listener);
+    }
 
-	@Configuration
-	public static class Config {
-	}
+    @Configuration
+    public static class Config {
+    }
 
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/SecurityConfigTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/SecurityConfigTests.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.statemachine.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.AccessDecisionManager;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/SecurityRuleTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/SecurityRuleTests.java
@@ -15,13 +15,15 @@
  */
 package org.springframework.statemachine.security;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class SecurityRuleTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityAttributeTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityAttributeTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.security;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.statemachine.StateMachine;
@@ -24,55 +24,55 @@ import org.springframework.statemachine.security.SecurityRule.ComparisonType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class TransitionSecurityAttributeTests extends AbstractSecurityTests {
 
-	@Test
-	@WithMockUser
-	public void testAnonymousRole() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    @WithMockUser
+    public void testAnonymousRole() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Test
-	@WithMockUser
-	public void testTransitionSource() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "TRANSITION_SOURCE_S0", ComparisonType.ANY, null);
-		assertTransitionAllowed(machine, listener);
-	}
+    @Test
+    @WithMockUser
+    public void testTransitionSource() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "TRANSITION_SOURCE_S0", ComparisonType.ANY, null);
+        assertTransitionAllowed(machine, listener);
+    }
 
-	@Test
-	@WithMockUser
-	public void testTransitionTarget() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "TRANSITION_TARGET_S1", ComparisonType.ANY, null);
-		assertTransitionAllowed(machine, listener);
-	}
+    @Test
+    @WithMockUser
+    public void testTransitionTarget() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "TRANSITION_TARGET_S1", ComparisonType.ANY, null);
+        assertTransitionAllowed(machine, listener);
+    }
 
-	@Test
-	@WithMockUser
-	public void testTransitionSourceAndTargetAll() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "TRANSITION_SOURCE_S0,TRANSITION_TARGET_S1", ComparisonType.ALL, null);
-		assertTransitionAllowed(machine, listener);
-	}
+    @Test
+    @WithMockUser
+    public void testTransitionSourceAndTargetAll() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "TRANSITION_SOURCE_S0,TRANSITION_TARGET_S1", ComparisonType.ALL, null);
+        assertTransitionAllowed(machine, listener);
+    }
 
-	@Test
-	@WithMockUser
-	public void testTransitionSourceAndTargetAny() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "TRANSITION_SOURCE_S0,TRANSITION_TARGET_S1", ComparisonType.ANY, null);
-		assertTransitionAllowed(machine, listener);
-	}
+    @Test
+    @WithMockUser
+    public void testTransitionSourceAndTargetAny() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "TRANSITION_SOURCE_S0,TRANSITION_TARGET_S1", ComparisonType.ANY, null);
+        assertTransitionAllowed(machine, listener);
+    }
 
-	@Configuration
-	public static class Config {
-	}
+    @Configuration
+    public static class Config {
+    }
 
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityExpressionRootTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityExpressionRootTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.security;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -43,7 +43,7 @@ public class TransitionSecurityExpressionRootTests {
 	private Authentication user;
 	private Transition<?, ?> transition;
 
-	@Before
+	@BeforeEach
 	public void createContext() {
 		user = mock(Authentication.class);
 		transition = mock(Transition.class);

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityExpressionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityExpressionTests.java
@@ -15,16 +15,16 @@
  */
 package org.springframework.statemachine.security;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -39,14 +39,14 @@ import org.springframework.statemachine.state.State;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests for securing transitions.
  *
  * @author Janne Valkealahti
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class TransitionSecurityExpressionTests extends AbstractStateMachineTests {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/TransitionSecurityTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.security;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.statemachine.StateMachine;
@@ -24,51 +24,51 @@ import org.springframework.statemachine.security.SecurityRule.ComparisonType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Tests for securing transitions.
  *
  * @author Janne Valkealahti
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 public class TransitionSecurityTests extends AbstractSecurityTests {
 
-	@Test
-	public void testNoSecurityContext() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    public void testNoSecurityContext() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Test
-	@WithMockUser(roles = { "ANONYMOUS" })
-	public void testTransitionAllowed() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
-		assertTransitionAllowed(machine, listener);
-	}
+    @Test
+    @WithMockUser(roles = {"ANONYMOUS"})
+    public void testTransitionAllowed() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
+        assertTransitionAllowed(machine, listener);
+    }
 
-	@Test
-	@WithMockUser(roles = { "FOO" })
-	public void testTransitionDenied() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    @WithMockUser(roles = {"FOO"})
+    public void testTransitionDenied() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, "ROLE_ANONYMOUS", ComparisonType.ANY, null);
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Test
-	@WithMockUser
-	public void testExpression() throws Exception {
-		TestListener listener = new TestListener();
-		StateMachine<States,Events> machine = buildMachine(listener, null, null, "hasTarget('S1')");
-		assertTransitionDenied(machine, listener);
-	}
+    @Test
+    @WithMockUser
+    public void testExpression() throws Exception {
+        TestListener listener = new TestListener();
+        StateMachine<States, Events> machine = buildMachine(listener, null, null, "hasTarget('S1')");
+        assertTransitionDenied(machine, listener);
+    }
 
-	@Configuration
-	public static class Config {
-	}
+    @Configuration
+    public static class Config {
+    }
 
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/service/DefaultStateMachineServiceTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/service/DefaultStateMachineServiceTests.java
@@ -16,11 +16,11 @@
 package org.springframework.statemachine.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/ChoiceStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/ChoiceStateTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/CompletionEventTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/CompletionEventTests.java
@@ -16,9 +16,9 @@
 package org.springframework.statemachine.state;
 
 import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -27,7 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/EndStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/EndStateTests.java
@@ -15,17 +15,17 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/EnumStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/EnumStateTests.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.AbstractStateMachineTests.TestEvents;
 import org.springframework.statemachine.AbstractStateMachineTests.TestStates;
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/ExitEntryStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/ExitEntryStateTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -25,7 +25,7 @@ import static org.springframework.statemachine.TestUtils.resolveMachine;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/ForkStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/ForkStateTests.java
@@ -15,16 +15,16 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/HistoryStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/HistoryStateTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/InitialStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/InitialStateTests.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;
@@ -52,10 +53,13 @@ public class InitialStateTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getIds(), contains(TestStates.S1));
 	}
 
-	@Test(expected = Exception.class)
+	@Test
 	public void testInitialStateMissingFailure() throws Exception {
-		context.register(BaseConfig.class, Config2.class);
-		context.refresh();
+		assertThrows(Exception.class, () -> {
+			context.register(BaseConfig.class, Config2.class);
+			context.refresh();
+		});
+
 	}
 
 	@SuppressWarnings({ "unchecked" })

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JoinPseudoStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JoinPseudoStateTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.TestUtils;
 
 public class JoinPseudoStateTests {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JoinStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JoinStateTests.java
@@ -15,11 +15,11 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JunctionStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/JunctionStateTests.java
@@ -15,16 +15,16 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/RegionStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/RegionStateTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.task.SyncTaskExecutor;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/StateActionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/StateActionTests.java
@@ -16,15 +16,15 @@
 package org.springframework.statemachine.state;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefEnumTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefEnumTests.java
@@ -15,14 +15,14 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -39,7 +39,6 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
  * Tests for submachine references.
  *
  * @author Janne Valkealahti
- *
  */
 public class SubmachineRefEnumTests extends AbstractStateMachineTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineRefTests.java
@@ -15,15 +15,15 @@
  */
 package org.springframework.statemachine.state;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveFactory;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineStateTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/state/SubmachineStateTests.java
@@ -16,14 +16,14 @@
 package org.springframework.statemachine.state;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -46,7 +46,6 @@ import org.springframework.statemachine.trigger.EventTrigger;
  * Tests for states using a submachine.
  *
  * @author Janne Valkealahti
- *
  */
 public class SubmachineStateTests extends AbstractStateMachineTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/DefaultStateMachineContextTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/DefaultStateMachineContextTests.java
@@ -15,13 +15,14 @@
  */
 package org.springframework.statemachine.support;
 
+import org.junit.jupiter.api.Test;
+
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;
 
-import org.junit.Test;
 
 public class DefaultStateMachineContextTests {
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/LifecycleObjectSupportTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/LifecycleObjectSupportTests.java
@@ -16,10 +16,9 @@
 package org.springframework.statemachine.support;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
 public class LifecycleObjectSupportTests {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/ReactiveLifecycleManagerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/ReactiveLifecycleManagerTests.java
@@ -16,12 +16,12 @@
 package org.springframework.statemachine.support;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.support.ReactiveLifecycleManager.LifecycleState;
 
 import reactor.core.publisher.Mono;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateChangeInterceptorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateChangeInterceptorTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.support;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.support;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/TransitionComparatorTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/TransitionComparatorTests.java
@@ -16,12 +16,12 @@
 package org.springframework.statemachine.support;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.AbstractStateMachineTests.TestEvents;
 import org.springframework.statemachine.AbstractStateMachineTests.TestStates;
 import org.springframework.statemachine.ObjectStateMachine;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/tree/TreeTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/tree/TreeTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.statemachine.support.tree;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.support.tree.Tree.Node;
 
 public class TreeTests {

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/LocalTransitionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/LocalTransitionTests.java
@@ -17,14 +17,14 @@ package org.springframework.statemachine.transition;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.AbstractStateMachineTests;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionEventHeaderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionEventHeaderTests.java
@@ -18,13 +18,13 @@ package org.springframework.statemachine.transition;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionOrderTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionOrderTests.java
@@ -16,8 +16,8 @@
 package org.springframework.statemachine.transition;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/transition/TransitionTests.java
@@ -19,8 +19,8 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/trigger/TimerTriggerTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/trigger/TimerTriggerTests.java
@@ -16,11 +16,11 @@
 package org.springframework.statemachine.trigger;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.resolveMachine;
@@ -31,7 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-kryo/src/test/java/org/springframework/statemachine/kryo/KryoStateMachineSerialisationServiceTests.java
+++ b/spring-statemachine-kryo/src/test/java/org/springframework/statemachine/kryo/KryoStateMachineSerialisationServiceTests.java
@@ -16,12 +16,12 @@
 package org.springframework.statemachine.kryo;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.support.DefaultExtendedState;
 import org.springframework.statemachine.support.DefaultStateMachineContext;

--- a/spring-statemachine-kryo/src/test/java/org/springframework/statemachine/kryo/StateMachineContextSerializerTests.java
+++ b/spring-statemachine-kryo/src/test/java/org/springframework/statemachine/kryo/StateMachineContextSerializerTests.java
@@ -16,7 +16,7 @@
 package org.springframework.statemachine.kryo;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.support.DefaultExtendedState;
 import org.springframework.statemachine.support.DefaultStateMachineContext;

--- a/spring-statemachine-recipes/src/test/java/org/springframework/statemachine/recipes/PersistStateMachineHandlerTests.java
+++ b/spring-statemachine-recipes/src/test/java/org/springframework/statemachine/recipes/PersistStateMachineHandlerTests.java
@@ -15,16 +15,16 @@
  */
 package org.springframework.statemachine.recipes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;

--- a/spring-statemachine-recipes/src/test/java/org/springframework/statemachine/recipes/TasksHandlerTests.java
+++ b/spring-statemachine-recipes/src/test/java/org/springframework/statemachine/recipes/TasksHandlerTests.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.statemachine.recipes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.StateMachineContext;
@@ -41,689 +41,689 @@ import org.springframework.statemachine.transition.Transition;
 
 public class TasksHandlerTests {
 
-	private final static Log log = LogFactory.getLog(TasksHandlerTests.class);
-
-	@Test
-	public void testRunOnceSimpleNoFailures() throws InterruptedException {
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(9, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(9));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-		Map<Object, Object> variables = machine.getExtendedState().getVariables();
-		assertThat(variables.size(), is(3));
-	}
-
-	@Test
-	public void testRunFail() throws InterruptedException {
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", failRunnable())
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(11, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(11));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
-		Map<Object, Object> variables = machine.getExtendedState().getVariables();
-		assertThat(variables.size(), is(3));
-	}
-
-	@Test
-	public void testRunFailAndFixAndContinue() throws InterruptedException {
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", failRunnable())
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(11, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(11));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
-
-		listener.reset(0, 0, 0, 0, 1);
-		handler.fixCurrentProblems();
-		assertThat(listener.extendedStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		listener.reset(1, 0, 0);
-		handler.continueFromError();
-		assertThat(listener.stateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(1));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-	}
-
-	@Test
-	public void testRunFailAndAutomaticFix() throws InterruptedException {
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", failRunnable())
-				.build();
-
-		TestTasksListener tasksListener = new TestTasksListener();
-		tasksListener.fix = true;
-		handler.addTasksListener(tasksListener);
-
-		TestListener listener = new TestListener();
-		listener.reset(1, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(1));
-
-		listener.reset(10, 0, 0);
-
-		handler.runTasks();
-		assertThat(listener.stateChangedLatch.await(4, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(10));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-	}
-
-	@Test
-	public void testDagSingleRoot() throws InterruptedException {
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("1", "12", sleepRunnable())
-				.task("1", "13", sleepRunnable())
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(9, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(12, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(9));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-		Map<Object, Object> variables = machine.getExtendedState().getVariables();
-		assertThat(variables.size(), is(3));
-	}
-
-	@Test
-	public void testDagMultiRoot() throws InterruptedException {
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("1", "12", sleepRunnable())
-				.task("1", "13", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("2", "22", sleepRunnable())
-				.task("2", "23", sleepRunnable())
-				.task("3", sleepRunnable())
-				.task("3", "32", sleepRunnable())
-				.task("3", "33", sleepRunnable())
-				.build();
-
-		TestListener listener = new TestListener();
-		StateMachine<String, String> machine = handler.getStateMachine();
-
-		machine.addStateListener(listener);
-		listener.reset(1, 0, 0);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(1));
-
-		listener.reset(20, 0, 0);
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(10, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(20));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-		Map<Object, Object> variables = machine.getExtendedState().getVariables();
-		assertThat(variables.size(), is(9));
-	}
-
-	@Test
-	public void testEvents1() throws InterruptedException {
-		TestTasksListener tasksListener = new TestTasksListener();
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.listener(tasksListener)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(9, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		tasksListener.reset(1, 0, 3, 3, 0, 3, 1, 0);
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(9));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-
-		assertThat(tasksListener.onTasksStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTasksStarted, is(1));
-		assertThat(tasksListener.onTaskPreExecuteLatch.await(3, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTaskPreExecute, is(3));
-		assertThat(tasksListener.onTaskPostExecuteLatch.await(3, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTaskPostExecute, is(3));
-		assertThat(tasksListener.onTaskFailed, is(0));
-		assertThat(tasksListener.onTaskSuccessLatch.await(3, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTaskSuccess, is(3));
-		assertThat(tasksListener.onTasksSuccessLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTasksSuccess, is(1));
-	}
-
-	@Test
-	public void testEvents2() throws InterruptedException {
-		TestTasksListener tasksListener = new TestTasksListener();
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", failRunnable())
-				.listener(tasksListener)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(11, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		tasksListener.reset(1, 0, 0, 0, 1, 0, 0, 1);
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(11));
-
-		assertThat(tasksListener.onTasksStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTasksStarted, is(1));
-		assertThat(tasksListener.onTaskSuccessLatch.await(2, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTaskSuccess, is(2));
-		assertThat(tasksListener.onTaskFailedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTaskFailed, is(1));
-		assertThat(tasksListener.onTasksErrorLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTasksError, is(1));
-		assertThat(tasksListener.onTasksSuccess, is(0));
-	}
-
-	@Test
-	public void testEvents3() throws InterruptedException {
-		TestTasksListener tasksListener = new TestTasksListener();
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", failRunnable())
-				.listener(tasksListener)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(11, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		tasksListener.reset(0, 1, 0, 0, 0, 0, 0, 0);
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(11));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
-
-		listener.reset(1, 0, 0);
-		handler.fixCurrentProblems();
-		handler.continueFromError();
-		assertThat(listener.stateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(1));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-
-		assertThat(tasksListener.onTasksContinueLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(tasksListener.onTasksContinue, is(1));
-	}
-
-	@Test
-	public void testPersist1() throws InterruptedException {
-		TestStateMachinePersist persist = new TestStateMachinePersist();
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.persist(persist)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(9, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		persist.reset(5);
-
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(9));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-		Map<Object, Object> variables = machine.getExtendedState().getVariables();
-		assertThat(variables.size(), is(3));
-
-		assertThat(persist.writeLatch.await(4, TimeUnit.SECONDS), is(true));
-		assertThat(persist.contexts.size(), is(5));
-
-		for (StateMachineContext<String, String> context : persist.getContexts()) {
-			if (context.getState() == "TASKS") {
-				assertThat(context.getChilds().size(), is(3));
-			} else {
-				assertThat(context.getChilds().size(), is(0));
-			}
-		}
-	}
-
-	@Test
-	public void testPersist2() throws InterruptedException {
-		TestStateMachinePersist persist = new TestStateMachinePersist();
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", failRunnable())
-				.persist(persist)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(11, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		doStartAndAssert(machine);
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		persist.reset(6);
-
-		handler.runTasks();
-
-		assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(11));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
-		Map<Object, Object> variables = machine.getExtendedState().getVariables();
-		assertThat(variables.size(), is(3));
-
-		assertThat(persist.writeLatch.await(4, TimeUnit.SECONDS), is(true));
-		assertThat(persist.contexts.size(), is(6));
-
-		for (StateMachineContext<String, String> context : persist.getContexts()) {
-			if (context.getState() == "TASKS") {
-				assertThat(context.getChilds().size(), is(3));
-			} else if (context.getState() == "ERROR") {
-				assertThat(context.getChilds().size(), is(1));
-			} else {
-				assertThat(context.getChilds().size(), is(0));
-			}
-		}
-	}
-
-	@Test
-	public void testReset1() throws InterruptedException {
-		TestStateMachinePersist persist = new TestStateMachinePersist();
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.persist(persist)
-				.build();
-
-		TestListener listener = new TestListener();
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-		handler.resetFromPersistStore();
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-	}
-
-	@Test
-	public void testReset2() throws InterruptedException {
-		DefaultStateMachineContext<String, String> child = new DefaultStateMachineContext<String, String>("MANUAL", null, null, null);
-		List<StateMachineContext<String, String>> childs = new ArrayList<StateMachineContext<String, String>>();
-		childs.add(child);
-		DefaultStateMachineContext<String, String> context = new DefaultStateMachineContext<String, String>(childs, "ERROR", null, null, null);
-		TestStateMachinePersist persist = new TestStateMachinePersist(context);
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.persist(persist)
-				.build();
-
-		TestListener listener = new TestListener();
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-
-		handler.resetFromPersistStore();
-
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
-	}
-
-	@Test
-	public void testReset3() throws InterruptedException {
-		log.info("testReset3 start");
-		List<StateMachineContext<String, String>> childs = new ArrayList<StateMachineContext<String, String>>();
-		DefaultStateMachineContext<String, String> context = new DefaultStateMachineContext<String, String>(childs, "ERROR", null, null, null);
-		TestStateMachinePersist persist = new TestStateMachinePersist(context);
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.persist(persist)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(2, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-
-		handler.resetFromPersistStore();
-
-		log.info("testReset3 wait stateMachineStartedLatch");
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		log.info("testReset3 wait stateChangedLatch");
-		assertThat(listener.stateChangedLatch.await(4, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(2));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-	}
-
-	//@Test
-	public void testReset4() throws InterruptedException {
-		// TODO: automaticAction() is not executed when state is reset
-		DefaultStateMachineContext<String, String> child = new DefaultStateMachineContext<String, String>("AUTOMATIC", null, null, null);
-		List<StateMachineContext<String, String>> childs = new ArrayList<StateMachineContext<String, String>>();
-		childs.add(child);
-		DefaultStateMachineContext<String, String> context = new DefaultStateMachineContext<String, String>(childs, "ERROR", null, null, null);
-		TestStateMachinePersist persist = new TestStateMachinePersist(context);
-		TasksHandler handler = TasksHandler.builder()
-				.task("1", sleepRunnable())
-				.task("2", sleepRunnable())
-				.task("3", sleepRunnable())
-				.persist(persist)
-				.build();
-
-		TestListener listener = new TestListener();
-		listener.reset(2, 0, 0);
-		StateMachine<String, String> machine = handler.getStateMachine();
-		machine.addStateListener(listener);
-
-		handler.resetFromPersistStore();
-
-		assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
-
-		assertThat(listener.stateChangedLatch.await(4, TimeUnit.SECONDS), is(true));
-		assertThat(listener.stateChangedCount, is(2));
-		assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
-	}
-
-	private static Runnable sleepRunnable() {
-		return new Runnable() {
-
-			@Override
-			public void run() {
-				try {
-					Thread.sleep(2000);
-				} catch (InterruptedException e) {
-				}
-			}
-		};
-	}
-
-	private static Runnable failRunnable() {
-		return new Runnable() {
-
-			@Override
-			public void run() {
-				throw new RuntimeException();
-			}
-		};
-	}
-
-	static class TestListener extends StateMachineListenerAdapter<String, String> {
-
-		private final Object lock = new Object();
-
-		volatile CountDownLatch stateMachineStartedLatch = new CountDownLatch(1);
-		volatile CountDownLatch stateChangedLatch = new CountDownLatch(1);
-		volatile CountDownLatch stateEnteredLatch = new CountDownLatch(2);
-		volatile CountDownLatch stateExitedLatch = new CountDownLatch(0);
-		volatile CountDownLatch transitionLatch = new CountDownLatch(0);
-		volatile CountDownLatch extendedStateChangedLatch = new CountDownLatch(0);
-		volatile int stateChangedCount = 0;
-		volatile int transitionCount = 0;
-		volatile int extendedStateChangedCount = 0;
-		List<State<String, String>> statesEntered = new ArrayList<State<String, String>>();
-		List<State<String, String>> statesExited = new ArrayList<State<String, String>>();
-
-		@Override
-		public void stateMachineStarted(StateMachine<String, String> stateMachine) {
-			synchronized (lock) {
-				stateMachineStartedLatch.countDown();
-			}
-		}
-
-		@Override
-		public void stateChanged(State<String, String> from, State<String, String> to) {
-			synchronized (lock) {
-				TasksHandlerTests.log.info("stateChanged "  + from + "::" + to);
-				stateChangedCount++;
-				stateChangedLatch.countDown();
-			}
-		}
-
-		@Override
-		public void stateEntered(State<String, String> state) {
-			synchronized (lock) {
-				statesEntered.add(state);
-				stateEnteredLatch.countDown();
-			}
-		}
-
-		@Override
-		public void stateExited(State<String, String> state) {
-			synchronized (lock) {
-				statesExited.add(state);
-				stateExitedLatch.countDown();
-			}
-		}
-
-		@Override
-		public void transitionEnded(Transition<String, String> transition) {
-			synchronized (lock) {
-				transitionCount++;
-				transitionLatch.countDown();
-			}
-		}
-
-		@Override
-		public void extendedStateChanged(Object key, Object value) {
-			synchronized (lock) {
-				extendedStateChangedCount++;
-				extendedStateChangedLatch.countDown();
-			}
-		}
-
-		public void reset(int c1, int c2, int c3) {
-			reset(c1, c2, c3, 0);
-		}
-
-		public void reset(int c1, int c2, int c3, int c4) {
-			reset(c1, c2, c3, c4, 0);
-		}
-
-		public void reset(int c1, int c2, int c3, int c4, int c5) {
-			synchronized (lock) {
-				stateChangedLatch = new CountDownLatch(c1);
-				stateEnteredLatch = new CountDownLatch(c2);
-				stateExitedLatch = new CountDownLatch(c3);
-				transitionLatch = new CountDownLatch(c4);
-				extendedStateChangedLatch = new CountDownLatch(c5);
-				stateChangedCount = 0;
-				transitionCount = 0;
-				extendedStateChangedCount = 0;
-				statesEntered.clear();
-				statesExited.clear();
-			}
-		}
-
-	}
-
-	private static class TestTasksListener extends TasksListenerAdapter {
-
-		final Object lock = new Object();
-
-		volatile CountDownLatch onTasksStartedLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTasksContinueLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTaskPreExecuteLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTaskPostExecuteLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTaskFailedLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTaskSuccessLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTasksSuccessLatch = new CountDownLatch(1);
-		volatile CountDownLatch onTasksErrorLatch = new CountDownLatch(1);
-
-		volatile int onTasksStarted;
-		volatile int onTasksContinue;
-		volatile int onTaskPreExecute;
-		volatile int onTaskPostExecute;
-		volatile int onTaskFailed;
-		volatile int onTaskSuccess;
-		volatile int onTasksSuccess;
-		volatile int onTasksError;
-
-		volatile boolean fix = false;
-
-		@Override
-		public void onTasksStarted() {
-			synchronized (lock) {
-				onTasksStarted++;
-				onTasksStartedLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTasksContinue() {
-			synchronized (lock) {
-				onTasksContinue++;
-				onTasksContinueLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTaskPreExecute(Object id) {
-			synchronized (lock) {
-				onTaskPreExecute++;
-				onTaskPreExecuteLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTaskPostExecute(Object id) {
-			synchronized (lock) {
-				onTaskPostExecute++;
-				onTaskPostExecuteLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTaskFailed(Object id, Exception exception) {
-			synchronized (lock) {
-				onTaskFailed++;
-				onTaskFailedLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTaskSuccess(Object id) {
-			synchronized (lock) {
-				onTaskSuccess++;
-				onTaskSuccessLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTasksSuccess() {
-			synchronized (lock) {
-				onTasksSuccess++;
-				onTasksSuccessLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTasksError() {
-			synchronized (lock) {
-				onTasksError++;
-				onTasksErrorLatch.countDown();
-			}
-		}
-
-		@Override
-		public void onTasksAutomaticFix(TasksHandler handler, StateContext<String, String> context) {
-			if (!fix) {
-				return;
-			}
-			handler.markAllTasksFixed();
-		}
-
-		public void reset(int c1, int c2, int c3, int c4, int c5, int c6, int c7, int c8) {
-			synchronized (lock) {
-				onTasksStartedLatch = new CountDownLatch(c1);
-				onTasksContinueLatch = new CountDownLatch(c2);
-				onTaskPreExecuteLatch = new CountDownLatch(c3);
-				onTaskPostExecuteLatch = new CountDownLatch(c4);
-				onTaskFailedLatch = new CountDownLatch(c5);
-				onTaskSuccessLatch = new CountDownLatch(c6);
-				onTasksSuccessLatch = new CountDownLatch(c7);
-				onTasksErrorLatch = new CountDownLatch(c8);
-				onTasksStarted = 0;
-				onTasksContinue = 0;
-				onTaskPreExecute = 0;
-				onTaskPostExecute = 0;
-				onTaskFailed = 0;
-				onTaskSuccess = 0;
-				onTasksSuccess = 0;
-				onTasksError = 0;
-			}
-		}
-
-	}
+    private final static Log log = LogFactory.getLog(TasksHandlerTests.class);
+
+    @Test
+    public void testRunOnceSimpleNoFailures() throws InterruptedException {
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(9, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(9));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+        Map<Object, Object> variables = machine.getExtendedState().getVariables();
+        assertThat(variables.size(), is(3));
+    }
+
+    @Test
+    public void testRunFail() throws InterruptedException {
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", failRunnable())
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(11, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(11));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
+        Map<Object, Object> variables = machine.getExtendedState().getVariables();
+        assertThat(variables.size(), is(3));
+    }
+
+    @Test
+    public void testRunFailAndFixAndContinue() throws InterruptedException {
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", failRunnable())
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(11, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(11));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
+
+        listener.reset(0, 0, 0, 0, 1);
+        handler.fixCurrentProblems();
+        assertThat(listener.extendedStateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        listener.reset(1, 0, 0);
+        handler.continueFromError();
+        assertThat(listener.stateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(1));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+    }
+
+    @Test
+    public void testRunFailAndAutomaticFix() throws InterruptedException {
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", failRunnable())
+            .build();
+
+        TestTasksListener tasksListener = new TestTasksListener();
+        tasksListener.fix = true;
+        handler.addTasksListener(tasksListener);
+
+        TestListener listener = new TestListener();
+        listener.reset(1, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(1));
+
+        listener.reset(10, 0, 0);
+
+        handler.runTasks();
+        assertThat(listener.stateChangedLatch.await(4, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(10));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+    }
+
+    @Test
+    public void testDagSingleRoot() throws InterruptedException {
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("1", "12", sleepRunnable())
+            .task("1", "13", sleepRunnable())
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(9, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(12, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(9));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+        Map<Object, Object> variables = machine.getExtendedState().getVariables();
+        assertThat(variables.size(), is(3));
+    }
+
+    @Test
+    public void testDagMultiRoot() throws InterruptedException {
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("1", "12", sleepRunnable())
+            .task("1", "13", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("2", "22", sleepRunnable())
+            .task("2", "23", sleepRunnable())
+            .task("3", sleepRunnable())
+            .task("3", "32", sleepRunnable())
+            .task("3", "33", sleepRunnable())
+            .build();
+
+        TestListener listener = new TestListener();
+        StateMachine<String, String> machine = handler.getStateMachine();
+
+        machine.addStateListener(listener);
+        listener.reset(1, 0, 0);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedLatch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(1));
+
+        listener.reset(20, 0, 0);
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(10, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(20));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+        Map<Object, Object> variables = machine.getExtendedState().getVariables();
+        assertThat(variables.size(), is(9));
+    }
+
+    @Test
+    public void testEvents1() throws InterruptedException {
+        TestTasksListener tasksListener = new TestTasksListener();
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .listener(tasksListener)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(9, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        tasksListener.reset(1, 0, 3, 3, 0, 3, 1, 0);
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(9));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+
+        assertThat(tasksListener.onTasksStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTasksStarted, is(1));
+        assertThat(tasksListener.onTaskPreExecuteLatch.await(3, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTaskPreExecute, is(3));
+        assertThat(tasksListener.onTaskPostExecuteLatch.await(3, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTaskPostExecute, is(3));
+        assertThat(tasksListener.onTaskFailed, is(0));
+        assertThat(tasksListener.onTaskSuccessLatch.await(3, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTaskSuccess, is(3));
+        assertThat(tasksListener.onTasksSuccessLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTasksSuccess, is(1));
+    }
+
+    @Test
+    public void testEvents2() throws InterruptedException {
+        TestTasksListener tasksListener = new TestTasksListener();
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", failRunnable())
+            .listener(tasksListener)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(11, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        tasksListener.reset(1, 0, 0, 0, 1, 0, 0, 1);
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(11));
+
+        assertThat(tasksListener.onTasksStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTasksStarted, is(1));
+        assertThat(tasksListener.onTaskSuccessLatch.await(2, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTaskSuccess, is(2));
+        assertThat(tasksListener.onTaskFailedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTaskFailed, is(1));
+        assertThat(tasksListener.onTasksErrorLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTasksError, is(1));
+        assertThat(tasksListener.onTasksSuccess, is(0));
+    }
+
+    @Test
+    public void testEvents3() throws InterruptedException {
+        TestTasksListener tasksListener = new TestTasksListener();
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", failRunnable())
+            .listener(tasksListener)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(11, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        tasksListener.reset(0, 1, 0, 0, 0, 0, 0, 0);
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(11));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
+
+        listener.reset(1, 0, 0);
+        handler.fixCurrentProblems();
+        handler.continueFromError();
+        assertThat(listener.stateChangedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(1));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+
+        assertThat(tasksListener.onTasksContinueLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(tasksListener.onTasksContinue, is(1));
+    }
+
+    @Test
+    public void testPersist1() throws InterruptedException {
+        TestStateMachinePersist persist = new TestStateMachinePersist();
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .persist(persist)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(9, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        persist.reset(5);
+
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(9));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+        Map<Object, Object> variables = machine.getExtendedState().getVariables();
+        assertThat(variables.size(), is(3));
+
+        assertThat(persist.writeLatch.await(4, TimeUnit.SECONDS), is(true));
+        assertThat(persist.contexts.size(), is(5));
+
+        for (StateMachineContext<String, String> context : persist.getContexts()) {
+            if (context.getState() == "TASKS") {
+                assertThat(context.getChilds().size(), is(3));
+            } else {
+                assertThat(context.getChilds().size(), is(0));
+            }
+        }
+    }
+
+    @Test
+    public void testPersist2() throws InterruptedException {
+        TestStateMachinePersist persist = new TestStateMachinePersist();
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", failRunnable())
+            .persist(persist)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(11, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        doStartAndAssert(machine);
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        persist.reset(6);
+
+        handler.runTasks();
+
+        assertThat(listener.stateChangedLatch.await(8, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(11));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
+        Map<Object, Object> variables = machine.getExtendedState().getVariables();
+        assertThat(variables.size(), is(3));
+
+        assertThat(persist.writeLatch.await(4, TimeUnit.SECONDS), is(true));
+        assertThat(persist.contexts.size(), is(6));
+
+        for (StateMachineContext<String, String> context : persist.getContexts()) {
+            if (context.getState() == "TASKS") {
+                assertThat(context.getChilds().size(), is(3));
+            } else if (context.getState() == "ERROR") {
+                assertThat(context.getChilds().size(), is(1));
+            } else {
+                assertThat(context.getChilds().size(), is(0));
+            }
+        }
+    }
+
+    @Test
+    public void testReset1() throws InterruptedException {
+        TestStateMachinePersist persist = new TestStateMachinePersist();
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .persist(persist)
+            .build();
+
+        TestListener listener = new TestListener();
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+        handler.resetFromPersistStore();
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+    }
+
+    @Test
+    public void testReset2() throws InterruptedException {
+        DefaultStateMachineContext<String, String> child = new DefaultStateMachineContext<String, String>("MANUAL", null, null, null);
+        List<StateMachineContext<String, String>> childs = new ArrayList<StateMachineContext<String, String>>();
+        childs.add(child);
+        DefaultStateMachineContext<String, String> context = new DefaultStateMachineContext<String, String>(childs, "ERROR", null, null, null);
+        TestStateMachinePersist persist = new TestStateMachinePersist(context);
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .persist(persist)
+            .build();
+
+        TestListener listener = new TestListener();
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+
+        handler.resetFromPersistStore();
+
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_ERROR, TasksHandler.STATE_MANUAL));
+    }
+
+    @Test
+    public void testReset3() throws InterruptedException {
+        log.info("testReset3 start");
+        List<StateMachineContext<String, String>> childs = new ArrayList<StateMachineContext<String, String>>();
+        DefaultStateMachineContext<String, String> context = new DefaultStateMachineContext<String, String>(childs, "ERROR", null, null, null);
+        TestStateMachinePersist persist = new TestStateMachinePersist(context);
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .persist(persist)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(2, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+
+        handler.resetFromPersistStore();
+
+        log.info("testReset3 wait stateMachineStartedLatch");
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        log.info("testReset3 wait stateChangedLatch");
+        assertThat(listener.stateChangedLatch.await(4, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(2));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+    }
+
+    //@Test
+    public void testReset4() throws InterruptedException {
+        // TODO: automaticAction() is not executed when state is reset
+        DefaultStateMachineContext<String, String> child = new DefaultStateMachineContext<String, String>("AUTOMATIC", null, null, null);
+        List<StateMachineContext<String, String>> childs = new ArrayList<StateMachineContext<String, String>>();
+        childs.add(child);
+        DefaultStateMachineContext<String, String> context = new DefaultStateMachineContext<String, String>(childs, "ERROR", null, null, null);
+        TestStateMachinePersist persist = new TestStateMachinePersist(context);
+        TasksHandler handler = TasksHandler.builder()
+            .task("1", sleepRunnable())
+            .task("2", sleepRunnable())
+            .task("3", sleepRunnable())
+            .persist(persist)
+            .build();
+
+        TestListener listener = new TestListener();
+        listener.reset(2, 0, 0);
+        StateMachine<String, String> machine = handler.getStateMachine();
+        machine.addStateListener(listener);
+
+        handler.resetFromPersistStore();
+
+        assertThat(listener.stateMachineStartedLatch.await(1, TimeUnit.SECONDS), is(true));
+
+        assertThat(listener.stateChangedLatch.await(4, TimeUnit.SECONDS), is(true));
+        assertThat(listener.stateChangedCount, is(2));
+        assertThat(machine.getState().getIds(), contains(TasksHandler.STATE_READY));
+    }
+
+    private static Runnable sleepRunnable() {
+        return new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                }
+            }
+        };
+    }
+
+    private static Runnable failRunnable() {
+        return new Runnable() {
+
+            @Override
+            public void run() {
+                throw new RuntimeException();
+            }
+        };
+    }
+
+    static class TestListener extends StateMachineListenerAdapter<String, String> {
+
+        private final Object lock = new Object();
+
+        volatile CountDownLatch stateMachineStartedLatch = new CountDownLatch(1);
+        volatile CountDownLatch stateChangedLatch = new CountDownLatch(1);
+        volatile CountDownLatch stateEnteredLatch = new CountDownLatch(2);
+        volatile CountDownLatch stateExitedLatch = new CountDownLatch(0);
+        volatile CountDownLatch transitionLatch = new CountDownLatch(0);
+        volatile CountDownLatch extendedStateChangedLatch = new CountDownLatch(0);
+        volatile int stateChangedCount = 0;
+        volatile int transitionCount = 0;
+        volatile int extendedStateChangedCount = 0;
+        List<State<String, String>> statesEntered = new ArrayList<State<String, String>>();
+        List<State<String, String>> statesExited = new ArrayList<State<String, String>>();
+
+        @Override
+        public void stateMachineStarted(StateMachine<String, String> stateMachine) {
+            synchronized (lock) {
+                stateMachineStartedLatch.countDown();
+            }
+        }
+
+        @Override
+        public void stateChanged(State<String, String> from, State<String, String> to) {
+            synchronized (lock) {
+                TasksHandlerTests.log.info("stateChanged " + from + "::" + to);
+                stateChangedCount++;
+                stateChangedLatch.countDown();
+            }
+        }
+
+        @Override
+        public void stateEntered(State<String, String> state) {
+            synchronized (lock) {
+                statesEntered.add(state);
+                stateEnteredLatch.countDown();
+            }
+        }
+
+        @Override
+        public void stateExited(State<String, String> state) {
+            synchronized (lock) {
+                statesExited.add(state);
+                stateExitedLatch.countDown();
+            }
+        }
+
+        @Override
+        public void transitionEnded(Transition<String, String> transition) {
+            synchronized (lock) {
+                transitionCount++;
+                transitionLatch.countDown();
+            }
+        }
+
+        @Override
+        public void extendedStateChanged(Object key, Object value) {
+            synchronized (lock) {
+                extendedStateChangedCount++;
+                extendedStateChangedLatch.countDown();
+            }
+        }
+
+        public void reset(int c1, int c2, int c3) {
+            reset(c1, c2, c3, 0);
+        }
+
+        public void reset(int c1, int c2, int c3, int c4) {
+            reset(c1, c2, c3, c4, 0);
+        }
+
+        public void reset(int c1, int c2, int c3, int c4, int c5) {
+            synchronized (lock) {
+                stateChangedLatch = new CountDownLatch(c1);
+                stateEnteredLatch = new CountDownLatch(c2);
+                stateExitedLatch = new CountDownLatch(c3);
+                transitionLatch = new CountDownLatch(c4);
+                extendedStateChangedLatch = new CountDownLatch(c5);
+                stateChangedCount = 0;
+                transitionCount = 0;
+                extendedStateChangedCount = 0;
+                statesEntered.clear();
+                statesExited.clear();
+            }
+        }
+
+    }
+
+    private static class TestTasksListener extends TasksListenerAdapter {
+
+        final Object lock = new Object();
+
+        volatile CountDownLatch onTasksStartedLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTasksContinueLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTaskPreExecuteLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTaskPostExecuteLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTaskFailedLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTaskSuccessLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTasksSuccessLatch = new CountDownLatch(1);
+        volatile CountDownLatch onTasksErrorLatch = new CountDownLatch(1);
+
+        volatile int onTasksStarted;
+        volatile int onTasksContinue;
+        volatile int onTaskPreExecute;
+        volatile int onTaskPostExecute;
+        volatile int onTaskFailed;
+        volatile int onTaskSuccess;
+        volatile int onTasksSuccess;
+        volatile int onTasksError;
+
+        volatile boolean fix = false;
+
+        @Override
+        public void onTasksStarted() {
+            synchronized (lock) {
+                onTasksStarted++;
+                onTasksStartedLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTasksContinue() {
+            synchronized (lock) {
+                onTasksContinue++;
+                onTasksContinueLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTaskPreExecute(Object id) {
+            synchronized (lock) {
+                onTaskPreExecute++;
+                onTaskPreExecuteLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTaskPostExecute(Object id) {
+            synchronized (lock) {
+                onTaskPostExecute++;
+                onTaskPostExecuteLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTaskFailed(Object id, Exception exception) {
+            synchronized (lock) {
+                onTaskFailed++;
+                onTaskFailedLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTaskSuccess(Object id) {
+            synchronized (lock) {
+                onTaskSuccess++;
+                onTaskSuccessLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTasksSuccess() {
+            synchronized (lock) {
+                onTasksSuccess++;
+                onTasksSuccessLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTasksError() {
+            synchronized (lock) {
+                onTasksError++;
+                onTasksErrorLatch.countDown();
+            }
+        }
+
+        @Override
+        public void onTasksAutomaticFix(TasksHandler handler, StateContext<String, String> context) {
+            if (!fix) {
+                return;
+            }
+            handler.markAllTasksFixed();
+        }
+
+        public void reset(int c1, int c2, int c3, int c4, int c5, int c6, int c7, int c8) {
+            synchronized (lock) {
+                onTasksStartedLatch = new CountDownLatch(c1);
+                onTasksContinueLatch = new CountDownLatch(c2);
+                onTaskPreExecuteLatch = new CountDownLatch(c3);
+                onTaskPostExecuteLatch = new CountDownLatch(c4);
+                onTaskFailedLatch = new CountDownLatch(c5);
+                onTaskSuccessLatch = new CountDownLatch(c6);
+                onTasksSuccessLatch = new CountDownLatch(c7);
+                onTasksErrorLatch = new CountDownLatch(c8);
+                onTasksStarted = 0;
+                onTasksContinue = 0;
+                onTaskPreExecute = 0;
+                onTaskPostExecute = 0;
+                onTaskFailed = 0;
+                onTaskSuccess = 0;
+                onTasksSuccess = 0;
+                onTasksError = 0;
+            }
+        }
+
+    }
 
 }

--- a/spring-statemachine-samples/cdplayer/src/test/java/demo/cdplayer/CdPlayerTests.java
+++ b/spring-statemachine-samples/cdplayer/src/test/java/demo/cdplayer/CdPlayerTests.java
@@ -15,12 +15,12 @@
  */
 package demo.cdplayer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
 
@@ -29,9 +29,9 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -269,7 +269,7 @@ public class CdPlayerTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		context = new AnnotationConfigApplicationContext();
 		context.register(CommonConfiguration.class, Application.class, TestConfig.class);
@@ -282,7 +282,7 @@ public class CdPlayerTests {
 		assertThat(listener.stateMachineStartedLatch.await(2, TimeUnit.SECONDS), is(true));
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		doStopAndAssert(machine);
 		context.close();

--- a/spring-statemachine-samples/datajpa/src/test/java/demo/datajpa/DataJpaTests.java
+++ b/spring-statemachine-samples/datajpa/src/test/java/demo/datajpa/DataJpaTests.java
@@ -21,20 +21,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class })
 @WebAppConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -70,7 +70,7 @@ public class DataJpaTests {
 						containsString("Exit S2"))));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/datajpamultipersist/src/test/java/demo/datajpamultipersist/DataJpaMultiPersistTests.java
+++ b/spring-statemachine-samples/datajpamultipersist/src/test/java/demo/datajpamultipersist/DataJpaMultiPersistTests.java
@@ -21,22 +21,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import demo.datajpamultipersist.Application;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class })
 @WebAppConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -114,7 +114,7 @@ public class DataJpaMultiPersistTests {
 				containsString("Enter null"))));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/datapersist/src/test/java/demo/datapersist/DataJpaPersistTests.java
+++ b/spring-statemachine-samples/datapersist/src/test/java/demo/datapersist/DataJpaPersistTests.java
@@ -21,23 +21,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import demo.datapersist.Application;
-import demo.datapersist.StateMachineController;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class })
 @WebAppConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -101,7 +100,7 @@ public class DataJpaPersistTests {
 			andExpect(content().string(containsString("Exit S2")));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/deploy/src/test/java/demo/deploy/DeployTests.java
+++ b/spring-statemachine-samples/deploy/src/test/java/demo/deploy/DeployTests.java
@@ -20,20 +20,21 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class})
 @WebAppConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -67,7 +68,7 @@ public class DeployTests {
 			andExpect(content().string(containsString("States: [READY]")));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/deploy/src/test/java/demo/deploy/StateMachineTests.java
+++ b/spring-statemachine-samples/deploy/src/test/java/demo/deploy/StateMachineTests.java
@@ -15,8 +15,9 @@
  */
 package demo.deploy;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.Message;
@@ -26,9 +27,9 @@ import org.springframework.statemachine.test.StateMachineTestPlan;
 import org.springframework.statemachine.test.StateMachineTestPlanBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { StateMachineConfig.class})
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class StateMachineTests {

--- a/spring-statemachine-samples/eventservice/src/test/java/demo/eventservice/EventServiceTests.java
+++ b/spring-statemachine-samples/eventservice/src/test/java/demo/eventservice/EventServiceTests.java
@@ -23,9 +23,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.HashMap;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
@@ -35,7 +36,7 @@ import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.StateMachinePersist;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -45,7 +46,7 @@ import demo.eventservice.EventServiceTests.Config;
 import demo.eventservice.StateMachineConfig.Events;
 import demo.eventservice.StateMachineConfig.States;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
 		Config.class }, properties = "spring.main.allow-bean-definition-overriding=true")
 @WebAppConfiguration
@@ -100,7 +101,7 @@ public class EventServiceTests {
 			andExpect(content().string(containsString("Extended State: {COUNT=1, ITEMS=1}")));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/monitoring/src/test/java/demo/monitoring/MonitoringTests.java
+++ b/spring-statemachine-samples/monitoring/src/test/java/demo/monitoring/MonitoringTests.java
@@ -27,20 +27,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class }, properties = { "endpoints.default.web.enabled=true" })
 @WebAppConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -103,7 +104,7 @@ public class MonitoringTests {
 			andExpect(jsonPath("$.*.info.transition", containsInAnyOrder("INITIAL_S1")));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/ordershipping/src/test/java/demo/ordershipping/OrdershippingTests.java
+++ b/spring-statemachine-samples/ordershipping/src/test/java/demo/ordershipping/OrdershippingTests.java
@@ -20,20 +20,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class})
 @WebAppConfiguration
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -86,7 +86,7 @@ public class OrdershippingTests {
 		andExpect(content().string(containsString("[ORDER_SHIPPED]")));
 	}
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		mvc = MockMvcBuilders.webAppContextSetup(context).build();
 	}

--- a/spring-statemachine-samples/ordershipping/src/test/java/demo/ordershipping/StateMachineTests.java
+++ b/spring-statemachine-samples/ordershipping/src/test/java/demo/ordershipping/StateMachineTests.java
@@ -15,9 +15,9 @@
  */
 package demo.ordershipping;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.messaging.support.MessageBuilder;
@@ -27,9 +27,9 @@ import org.springframework.statemachine.test.StateMachineTestPlan;
 import org.springframework.statemachine.test.StateMachineTestPlanBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { StateMachineConfig.class})
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class StateMachineTests {
@@ -39,7 +39,7 @@ public class StateMachineTests {
 
 	private StateMachine<String, String> stateMachine;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		stateMachine = stateMachineFactory.getStateMachine();
 		// plan don't know how to wait if machine is started

--- a/spring-statemachine-samples/persist/src/test/java/demo/persist/PersistTests.java
+++ b/spring-statemachine-samples/persist/src/test/java/demo/persist/PersistTests.java
@@ -15,10 +15,10 @@
  */
 package demo.persist;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
 import java.util.ArrayList;
@@ -26,8 +26,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.statemachine.StateMachine;
@@ -36,11 +36,11 @@ import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.transition.Transition;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import demo.CommonConfiguration;
 
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @DirtiesContext(classMode=ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest(classes = { CommonConfiguration.class, Application.class, StateMachineCommands.class })
 public class PersistTests {

--- a/spring-statemachine-samples/showcase/src/test/java/demo/showcase/ShowcaseTests.java
+++ b/spring-statemachine-samples/showcase/src/test/java/demo/showcase/ShowcaseTests.java
@@ -15,9 +15,9 @@
  */
 package demo.showcase;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -356,7 +356,7 @@ public class ShowcaseTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = new AnnotationConfigApplicationContext();
 		context.register(CommonConfiguration.class, Application.class, Config.class);
@@ -366,7 +366,7 @@ public class ShowcaseTests {
 		doStartAndAssert(machine);
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		doStopAndAssert(machine);
 		context.close();

--- a/spring-statemachine-samples/tasks/src/test/java/demo/tasks/TasksTests.java
+++ b/spring-statemachine-samples/tasks/src/test/java/demo/tasks/TasksTests.java
@@ -15,9 +15,9 @@
  */
 package demo.tasks;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
 
@@ -29,9 +29,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -138,7 +138,7 @@ public class TasksTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		context = new AnnotationConfigApplicationContext();
 		context.register(CommonConfiguration.class, Application.class, TestConfig.class);
@@ -152,7 +152,7 @@ public class TasksTests {
 		assertThat(machine.getState().getIds(), contains(States.READY));
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		doStopAndAssert(machine);
 		context.close();

--- a/spring-statemachine-samples/turnstile/src/test/java/demo/turnstile/TurnstileTests.java
+++ b/spring-statemachine-samples/turnstile/src/test/java/demo/turnstile/TurnstileTests.java
@@ -15,9 +15,9 @@
  */
 package demo.turnstile;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
 
@@ -26,9 +26,9 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -136,7 +136,7 @@ public class TurnstileTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = new AnnotationConfigApplicationContext();
 		context.register(CommonConfiguration.class, Application.class, Config.class, StateMachineCommands.class);
@@ -146,7 +146,7 @@ public class TurnstileTests {
 		commands = context.getBean(StateMachineCommands.class);
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		doStopAndAssert(machine);
 		context.close();

--- a/spring-statemachine-samples/washer/src/test/java/demo/washer/WasherTests.java
+++ b/spring-statemachine-samples/washer/src/test/java/demo/washer/WasherTests.java
@@ -15,9 +15,9 @@
  */
 package demo.washer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 import static org.springframework.statemachine.TestUtils.doStopAndAssert;
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -166,7 +166,7 @@ public class WasherTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = new AnnotationConfigApplicationContext();
 		context.register(CommonConfiguration.class, Application.class, Config.class);
@@ -176,7 +176,7 @@ public class WasherTests {
 		doStartAndAssert(machine);
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		doStopAndAssert(machine);
 		context.close();

--- a/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/StateMachineTestPlan.java
+++ b/spring-statemachine-test/src/main/java/org/springframework/statemachine/test/StateMachineTestPlan.java
@@ -15,13 +15,13 @@
  */
 package org.springframework.statemachine.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -266,7 +266,7 @@ public class StateMachineTestPlan<S, E> {
 				for (StateMachine<S, E> stateMachine : stateMachines.values()) {
 					Map<Object, Object> variables = stateMachine.getExtendedState().getVariables();
 					for (Object key : step.expectVariableKeys) {
-						org.hamcrest.MatcherAssert.assertThat(
+						assertThat(
 								"Key [" + key + "] doesn't exist in extended state variables", variables,
 								IsMapContaining.hasKey(key));
 					}
@@ -277,7 +277,7 @@ public class StateMachineTestPlan<S, E> {
 				for (StateMachine<S, E> stateMachine : stateMachines.values()) {
 					Map<Object, Object> variables = stateMachine.getExtendedState().getVariables();
 					for (Matcher<Map<? extends Object, ?>> matcher : step.expectVariableMatchers) {
-						org.hamcrest.MatcherAssert.assertThat(variables, matcher);
+						assertThat(variables, matcher);
 					}
 				}
 			}
@@ -286,7 +286,7 @@ public class StateMachineTestPlan<S, E> {
 				for (StateMachine<S, E> stateMachine : stateMachines.values()) {
 					Map<Object, Object> variables = stateMachine.getExtendedState().getVariables();
 					for (Entry<Object, Object> entry : step.expectVariables.entrySet()) {
-						org.hamcrest.MatcherAssert.assertThat(
+						assertThat(
 								"Entry with key=[" + entry.getKey() + "] value=[" + entry.getValue()
 										+ "] doesn't exist in extended state variables",
 								variables, IsMapContaining.hasEntry(entry.getKey(), entry.getValue()));

--- a/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/AbstractUmlTests.java
+++ b/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/AbstractUmlTests.java
@@ -15,29 +15,29 @@
  */
 package org.springframework.statemachine.uml;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public abstract class AbstractUmlTests {
 
-	protected AnnotationConfigApplicationContext context;
+    protected AnnotationConfigApplicationContext context;
 
-	@Before
-	public void setup() {
-		context = buildContext();
-	}
+    @BeforeEach
+    public void setup() {
+        context = buildContext();
+    }
 
-	@After
-	public void clean() {
-		if (context != null) {
-			context.close();
-		}
-		context = null;
-	}
+    @AfterEach
+    public void clean() {
+        if (context != null) {
+            context.close();
+        }
+        context = null;
+    }
 
-	protected AnnotationConfigApplicationContext buildContext() {
-		return null;
-	}
+    protected AnnotationConfigApplicationContext buildContext() {
+        return null;
+    }
 
 }

--- a/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
+++ b/spring-statemachine-uml/src/test/java/org/springframework/statemachine/uml/UmlStateMachineModelFactoryTests.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.statemachine.uml;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
 import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
 import static org.springframework.statemachine.TestUtils.doStartAndAssert;
 
@@ -29,7 +29,7 @@ import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/AbstractZookeeperTests.java
+++ b/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/AbstractZookeeperTests.java
@@ -21,8 +21,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.curator.test.TestingServer;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -33,12 +33,12 @@ public abstract class AbstractZookeeperTests {
 
 	protected AnnotationConfigApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		context = buildContext();
 	}
 
-	@After
+	@AfterEach
 	public void clean() {
 		if (context != null) {
 			context.close();

--- a/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachineEnsembleTests.java
+++ b/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachineEnsembleTests.java
@@ -15,12 +15,13 @@
  */
 package org.springframework.statemachine.zookeeper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -32,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.KeeperException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.messaging.Message;
 import org.springframework.statemachine.ExtendedState;
@@ -231,9 +232,10 @@ public class ZookeeperStateMachineEnsembleTests extends AbstractZookeeperTests {
 		assertThat(curatorClient.getData().forPath("/foo/data/log/3").length, greaterThan(0));
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void testIllegalLogSize() throws Exception {
-				new ZookeeperStateMachineEnsemble<String, String>(null, "/foo", true, 3);
+		assertThrows(IllegalStateException.class,
+			() -> new ZookeeperStateMachineEnsemble<String, String>(null, "/foo", true, 3));
 	}
 
 	@Test

--- a/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachinePersistTests.java
+++ b/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachinePersistTests.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.statemachine.zookeeper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.data.Stat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.statemachine.StateMachineContext;

--- a/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachineTests.java
+++ b/spring-statemachine-zookeeper/src/test/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachineTests.java
@@ -15,16 +15,16 @@
  */
 package org.springframework.statemachine.zookeeper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;


### PR DESCRIPTION
1. remove junit4 dependencies. But the junit4 in spring-machine-test and spring-statemachine-build-tests are still there. And adding the junit5-vintage dependencies into those two submodules so that they can work together with junit4/junit5.

2. refactor the unit tests by using junit5. The most important changes are:
    2.1 junit.Test -> jupiter.Test
    2.2 Before -> BeforeEach
    2.3 After -> AfterEach
    2.4 juint.assertThat -> org.hamcrest.MatcherAssert.assertThat
    2.5 RunWith(SpringJunit4Runner) -> ExtendWith(SpringExtendsion)

related #779 
