### PR TITLE
Initial reactive Guard changes

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineTransitionBuilder.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineTransitionBuilder.java
@@ -54,7 +54,6 @@ import org.springframework.statemachine.config.model.HistoryData;
 import org.springframework.statemachine.config.model.JunctionData;
 import org.springframework.statemachine.config.model.TransitionData;
 import org.springframework.statemachine.config.model.TransitionsData;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.transition.TransitionKind;
 
@@ -179,8 +178,8 @@ public class StateMachineTransitionBuilder<S, E>
 	 * @param securityRule the security rule
 	 */
 	public void addTransition(S source, S target, S state, E event, Long period, Integer count,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, Guard<S, E> guard, TransitionKind kind,
-			SecurityRule securityRule) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, TransitionKind kind, SecurityRule securityRule) {
 		// if rule not given, get it from global
 		if (securityRule == null) {
 			@SuppressWarnings("unchecked")

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/AbstractTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/AbstractTransitionConfigurer.java
@@ -27,6 +27,7 @@ import org.springframework.statemachine.config.builders.StateMachineTransitionCo
 import org.springframework.statemachine.config.common.annotation.AnnotationConfigurerAdapter;
 import org.springframework.statemachine.config.model.TransitionsData;
 import org.springframework.statemachine.guard.Guard;
+import org.springframework.statemachine.guard.Guards;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.security.SecurityRule.ComparisonType;
 
@@ -50,7 +51,7 @@ public abstract class AbstractTransitionConfigurer<S, E> extends
 	private Long period;
 	private Integer count;
 	private final Collection<Function<StateContext<S, E>, Mono<Void>>> actions = new ArrayList<>();
-	private Guard<S, E> guard;
+	private Function<StateContext<S, E>, Mono<Boolean>> guard;
 	private SecurityRule securityRule;
 
 	protected S getSource() {
@@ -85,7 +86,7 @@ public abstract class AbstractTransitionConfigurer<S, E> extends
 		return actions;
 	}
 
-	protected Guard<S, E> getGuard() {
+	protected Function<StateContext<S, E>, Mono<Boolean>> getGuard() {
 		return guard;
 	}
 
@@ -134,6 +135,10 @@ public abstract class AbstractTransitionConfigurer<S, E> extends
 	}
 
 	protected void setGuard(Guard<S, E> guard) {
+		this.guard = Guards.from(guard);
+	}
+
+	protected void setGuardFunction(Function<StateContext<S, E>, Mono<Boolean>> guard) {
 		this.guard = guard;
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/TransitionData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/TransitionData.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.transition.TransitionKind;
 
@@ -39,7 +38,7 @@ public class TransitionData<S, E> {
 	private final Long period;
 	private final Integer count;
 	private final Collection<Function<StateContext<S, E>, Mono<Void>>> actions;
-	private final Guard<S, E> guard;
+	private final Function<StateContext<S, E>, Mono<Boolean>> guard;
 	private final TransitionKind kind;
 	private final SecurityRule securityRule;
 
@@ -65,7 +64,7 @@ public class TransitionData<S, E> {
 	 * @param kind the kind
 	 */
 	public TransitionData(S source, S target, E event, Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
-			Guard<S, E> guard, TransitionKind kind) {
+			Function<StateContext<S, E>, Mono<Boolean>> guard, TransitionKind kind) {
 		this(source, target, null, event, null, null, actions, guard, kind, null);
 	}
 
@@ -81,7 +80,8 @@ public class TransitionData<S, E> {
 	 * @param kind the kind
 	 */
 	public TransitionData(S source, S target, Long period, Integer count,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, Guard<S, E> guard, TransitionKind kind) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, TransitionKind kind) {
 		this(source, target, null, null, period, count, actions, guard, kind, null);
 	}
 
@@ -100,8 +100,8 @@ public class TransitionData<S, E> {
 	 * @param securityRule the security rule
 	 */
 	public TransitionData(S source, S target, S state, E event, Long period, Integer count,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, Guard<S, E> guard, TransitionKind kind,
-			SecurityRule securityRule) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, TransitionKind kind, SecurityRule securityRule) {
 		this.source = source;
 		this.target = target;
 		this.state = state;
@@ -182,7 +182,7 @@ public class TransitionData<S, E> {
 	 *
 	 * @return the guard
 	 */
-	public Guard<S, E> getGuard() {
+	public Function<StateContext<S, E>, Mono<Boolean>> getGuard() {
 		return guard;
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/guard/Guards.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/guard/Guards.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.guard;
+
+import java.util.function.Function;
+
+import org.springframework.statemachine.StateContext;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Guard Utilities.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public final class Guards {
+
+	/**
+	 * Builds a {@link ReactiveGuard} from a {@link Guard}.
+	 *
+	 * @param <S> the type of state
+	 * @param <E> the type of event
+	 * @param guard the guard
+	 * @return the function
+	 */
+	public static <S, E> Function<StateContext<S, E>, Mono<Boolean>> from(Guard<S, E> guard) {
+		if (guard != null) {
+			return context -> Mono.fromSupplier(() -> guard.evaluate(context));
+		} else {
+			// TODO: REACTOR think if should just return funtion evaluating true as null guard
+			// essentially is like a guard evaluating true, thought we'd prevent on dummy call.
+			return null;
+		}
+	}
+}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/guard/ReactiveGuard.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/guard/ReactiveGuard.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.guard;
+
+import java.util.function.Function;
+
+import org.springframework.statemachine.StateContext;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Reactive counterpart of a {@link Guard} being simply a {@link Function} of a
+ * return type of a {@link Mono} wrapping {@link Boolean}.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <S> the type of state
+ * @param <E> the type of event
+ */
+public interface ReactiveGuard<S, E> extends Function<StateContext<S, E>, Mono<Boolean>> {
+}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractExternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractExternalTransition.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -40,8 +39,8 @@ public abstract class AbstractExternalTransition<S, E> extends AbstractTransitio
 	 * @param securityRule the security rule
 	 */
 	public AbstractExternalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger, SecurityRule securityRule) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, TransitionKind.EXTERNAL, guard, trigger, securityRule);
 	}
 
@@ -56,8 +55,8 @@ public abstract class AbstractExternalTransition<S, E> extends AbstractTransitio
 	 * @param trigger the trigger
 	 */
 	public AbstractExternalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger) {
 		super(source, target, actions, event, TransitionKind.EXTERNAL, guard, trigger);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractInternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractInternalTransition.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -38,7 +37,7 @@ public class AbstractInternalTransition<S, E> extends AbstractTransition<S, E> i
 	 * @param trigger the trigger
 	 */
 	public AbstractInternalTransition(State<S, E> source, Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
-			E event, Guard<S, E> guard, Trigger<S, E> trigger) {
+			E event, Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger) {
 		super(source, source, actions, event, TransitionKind.INTERNAL, guard, trigger);
 	}
 
@@ -53,7 +52,8 @@ public class AbstractInternalTransition<S, E> extends AbstractTransition<S, E> i
 	 * @param securityRule the security rule
 	 */
 	public AbstractInternalTransition(State<S, E> source, Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
-			E event, Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
+			E event, Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger,
+			SecurityRule securityRule) {
 		super(source, source, actions, event, TransitionKind.INTERNAL, guard, trigger, securityRule);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractLocalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractLocalTransition.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -39,8 +38,8 @@ public class AbstractLocalTransition<S, E> extends AbstractTransition<S, E> impl
 	 * @param trigger the trigger
 	 */
 	public AbstractLocalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger) {
 		super(source, target, actions, event, TransitionKind.LOCAL, guard, trigger);
 	}
 
@@ -56,8 +55,8 @@ public class AbstractLocalTransition<S, E> extends AbstractTransition<S, E> impl
 	 * @param securityRule the security rule
 	 */
 	public AbstractLocalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger, SecurityRule securityRule) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, TransitionKind.LOCAL, guard, trigger, securityRule);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultExternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultExternalTransition.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -39,8 +38,8 @@ public class DefaultExternalTransition<S, E> extends AbstractExternalTransition<
 	 * @param trigger the trigger
 	 */
 	public DefaultExternalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger) {
 		super(source, target, actions, event, guard, trigger);
 	}
 
@@ -56,8 +55,8 @@ public class DefaultExternalTransition<S, E> extends AbstractExternalTransition<
 	 * @param securityRule the security rule
 	 */
 	public DefaultExternalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger, SecurityRule securityRule) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, guard, trigger, securityRule);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultInternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultInternalTransition.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -38,7 +37,7 @@ public class DefaultInternalTransition<S, E> extends AbstractInternalTransition<
 	 * @param trigger the trigger
 	 */
 	public DefaultInternalTransition(State<S, E> source, Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
-			E event, Guard<S, E> guard, Trigger<S, E> trigger) {
+			E event, Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger) {
 		super(source, actions, event, guard, trigger);
 	}
 
@@ -53,7 +52,8 @@ public class DefaultInternalTransition<S, E> extends AbstractInternalTransition<
 	 * @param securityRule the security rule
 	 */
 	public DefaultInternalTransition(State<S, E> source, Collection<Function<StateContext<S, E>, Mono<Void>>> actions,
-			E event, Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
+			E event, Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger,
+			SecurityRule securityRule) {
 		super(source, actions, event, guard, trigger, securityRule);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultLocalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultLocalTransition.java
@@ -39,8 +39,8 @@ public class DefaultLocalTransition<S, E> extends AbstractLocalTransition<S, E> 
 	 * @param trigger the trigger
 	 */
 	public DefaultLocalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger) {
 		super(source, target, actions, event, guard, trigger);
 	}
 
@@ -56,8 +56,8 @@ public class DefaultLocalTransition<S, E> extends AbstractLocalTransition<S, E> 
 	 * @param securityRule the security rule
 	 */
 	public DefaultLocalTransition(State<S, E> source, State<S, E> target,
-			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event, Guard<S, E> guard,
-			Trigger<S, E> trigger, SecurityRule securityRule) {
+			Collection<Function<StateContext<S, E>, Mono<Void>>> actions, E event,
+			Function<StateContext<S, E>, Mono<Boolean>> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, guard, trigger, securityRule);
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.ActionListener;
-import org.springframework.statemachine.guard.Guard;
 import org.springframework.statemachine.security.SecurityRule;
 import org.springframework.statemachine.state.State;
 import org.springframework.statemachine.trigger.Trigger;
@@ -73,7 +72,7 @@ public interface Transition<S, E> {
 	 *
 	 * @return the guard
 	 */
-	Guard<S, E> getGuard();
+	Function<StateContext<S, E>, Mono<Boolean>> getGuard();
 
 	/**
 	 * Gets the transition actions.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
@@ -125,7 +125,7 @@ public class StateContextExpressionMethodsTests {
 		}
 
 		@Override
-		public Guard<SpelStates, SpelEvents> getGuard() {
+		public Function<StateContext<SpelStates, SpelEvents>, Mono<Boolean>> getGuard() {
 			return null;
 		}
 

--- a/spring-statemachine-data/src/main/java/org/springframework/statemachine/data/RepositoryStateMachineModelFactory.java
+++ b/spring-statemachine-data/src/main/java/org/springframework/statemachine/data/RepositoryStateMachineModelFactory.java
@@ -45,6 +45,7 @@ import org.springframework.statemachine.config.model.StatesData;
 import org.springframework.statemachine.config.model.TransitionData;
 import org.springframework.statemachine.config.model.TransitionsData;
 import org.springframework.statemachine.guard.Guard;
+import org.springframework.statemachine.guard.Guards;
 import org.springframework.statemachine.guard.SpelExpressionGuard;
 import org.springframework.statemachine.state.PseudoStateKind;
 import org.springframework.statemachine.transition.TransitionKind;
@@ -225,7 +226,8 @@ public class RepositoryStateMachineModelFactory extends AbstractStateMachineMode
 			TransitionKind kind = t.getKind();
 
 			Guard<String, String> guard = resolveGuard(t);
-			transitionData.add(new TransitionData<>(t.getSource().getState(), t.getTarget().getState(), t.getEvent(), actions, guard, kind != null ? kind : TransitionKind.EXTERNAL));
+			transitionData.add(new TransitionData<>(t.getSource().getState(), t.getTarget().getState(), t.getEvent(),
+					actions, Guards.from(guard), kind != null ? kind : TransitionKind.EXTERNAL));
 
 			if (t.getSource().getKind() == PseudoStateKind.ENTRY) {
 				entrys.add(new EntryData<String, String>(t.getSource().getState(), t.getTarget().getState()));

--- a/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
+++ b/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
@@ -65,6 +65,7 @@ import org.springframework.statemachine.config.model.StatesData;
 import org.springframework.statemachine.config.model.TransitionData;
 import org.springframework.statemachine.config.model.TransitionsData;
 import org.springframework.statemachine.guard.Guard;
+import org.springframework.statemachine.guard.Guards;
 import org.springframework.statemachine.guard.SpelExpressionGuard;
 import org.springframework.statemachine.state.PseudoStateKind;
 import org.springframework.util.Assert;
@@ -381,13 +382,13 @@ public class UmlModelParser {
 								transitionDatas
 										.add(new TransitionData<String, String>(resolveName(transition.getSource()),
 												cprentries.get(0).getName(), signal.getName(),
-												UmlUtils.resolveTransitionActionFunctions(transition, resolver), guard,
-												UmlUtils.mapUmlTransitionType(transition)));
+												UmlUtils.resolveTransitionActionFunctions(transition, resolver),
+												Guards.from(guard), UmlUtils.mapUmlTransitionType(transition)));
 							}
 						} else {
 							transitionDatas.add(new TransitionData<String, String>(resolveName(transition.getSource()),
 									resolveName(transition.getTarget()), signal.getName(),
-									UmlUtils.resolveTransitionActionFunctions(transition, resolver), guard,
+									UmlUtils.resolveTransitionActionFunctions(transition, resolver), Guards.from(guard),
 									UmlUtils.mapUmlTransitionType(transition)));
 						}
 					}
@@ -401,7 +402,7 @@ public class UmlModelParser {
 						}
 						transitionDatas.add(new TransitionData<String, String>(resolveName(transition.getSource()),
 								resolveName(transition.getTarget()), period, count,
-								UmlUtils.resolveTransitionActionFunctions(transition, resolver), guard,
+								UmlUtils.resolveTransitionActionFunctions(transition, resolver), Guards.from(guard),
 								UmlUtils.mapUmlTransitionType(transition)));
 					}
 				}
@@ -411,8 +412,8 @@ public class UmlModelParser {
 			if (shouldCreateAnonymousTransition(transition)) {
 				transitionDatas.add(new TransitionData<String, String>(resolveName(transition.getSource()),
 						resolveName(transition.getTarget()), null,
-						UmlUtils.resolveTransitionActionFunctions(transition, resolver), resolveGuard(transition),
-						UmlUtils.mapUmlTransitionType(transition)));
+						UmlUtils.resolveTransitionActionFunctions(transition, resolver),
+						Guards.from(resolveGuard(transition)), UmlUtils.mapUmlTransitionType(transition)));
 			}
 		}
 	}


### PR DESCRIPTION
- First changes to introduce ReactiveGuard similar to work done
  for ReactiveAction. User level interface is ReactiveGuard but internally
  it is handled as its super type Function<StateContext<S, E>, Mono<Boolean>>.
- This change still keeps some calls as blocking which will get changed
  in futher commits to get a full reactive chain.
- Touching only Transition to change guard signature, other use of blocking guard
  internally need to get similar changes in next commits.
- Baby steps...
- Relates #791