### PR TITLE
Fix NPR in ReactiveStateMachineExecutor

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveStateMachineExecutor.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveStateMachineExecutor.java
@@ -269,7 +269,10 @@ public class ReactiveStateMachineExecutor<S, E> extends LifecycleObjectSupport i
 
 				// most likely timer
 				if (trans.isEmpty()) {
-					trans.add(triggerToTransitionMap.get(queueItem.trigger));
+					Transition<S, E> t = triggerToTransitionMap.get(queueItem.trigger);
+					if (t != null) {
+						trans.add(t);
+					}
 				}
 
 				// go through candidates and transit max one, sort before handling

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventDeferTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/EventDeferTests.java
@@ -91,10 +91,7 @@ public class EventDeferTests extends AbstractStateMachineTests {
 		assertThat(readField.size(), is(3));
 	}
 
-	// @Test
-	// TODO: REACTOR disable for now to figure out what a hell!
-	// java.lang.NullPointerException: The iterator returned a null value
-	// from reactor and every attempt to figure it out failed
+	@Test
 	public void testDeferSmokeExecutorConcurrentModification() throws Exception {
 		context.register(Config5.class);
 		context.refresh();


### PR DESCRIPTION
- Re-enable test in EventDeferTests as this NPE fix
  now handles smoke test.
- Relates #791