### PR TITLE
Failed to reset state machine with given context

### DIFF
--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/Gh737TestsPlus.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/Gh737TestsPlus.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.buildtests;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+import static org.springframework.statemachine.TestUtils.doSendEventAndConsumeAll;
+import static org.springframework.statemachine.TestUtils.doStartAndAssert;
+import static org.springframework.statemachine.TestUtils.resolveMachine;
+
+import org.junit.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineContext;
+import org.springframework.statemachine.config.EnableStateMachine;
+import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
+import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
+import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
+import org.springframework.statemachine.guard.Guard;
+import org.springframework.statemachine.support.DefaultStateMachineContext;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class Gh737TestsPlus extends AbstractBuildTests {
+
+	@Test
+	public void test() throws Exception {
+		context.register(Config1.class);
+		context.refresh();
+		StateMachine<Status, Event> machine = resolveMachine(context);
+
+		//I don't want to start the state machine until I reset the state machine with given context.
+//		doStartAndAssert(machine);
+
+		StateMachineContext stateMachineContext = new DefaultStateMachineContext(Status.CLOSED, null, null, null, null, null);
+		machine.getStateMachineAccessor().doWithRegion(function -> function.resetStateMachine(stateMachineContext));
+
+		doSendEventAndConsumeAll(machine, Event.NEW);
+		assertThat(machine.getState().getIds(), containsInAnyOrder(Status.CLOSED));
+	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config1 extends EnumStateMachineConfigurerAdapter<Status, Event> {
+
+		@Override
+		public void configure(StateMachineStateConfigurer<Status, Event> states) throws Exception {
+			states
+				.withStates()
+					.initial(Status.ROOT)
+					.states(new HashSet<>(Arrays.asList(Status.ROOT, Status.CLOSED)))
+					.and()
+					.withStates()
+						.parent(Status.ROOT)
+						.initial(Status.S0)
+						.state(Status.S0)
+						.state(Status.S1)
+						.fork(Status.FORK_S2)
+						.state(Status.S2)
+						.join(Status.JOIN_S2)
+						.state(Status.S3)
+						.state(Status.S4)
+						.state(Status.S5)
+						.and()
+							.withStates()
+							.parent(Status.S2)
+							.initial(Status.S21I)
+							.state(Status.S21_IN_PROGRESS)
+							.state(Status.S21_NOT_REQUIRED)
+							.end(Status.S21E)
+							.and()
+						.withStates()
+							.parent(Status.S2)
+							.initial(Status.S22I)
+							.state(Status.S22_IN_PROGRESS)
+							.state(Status.S22_PASSED)
+							.end(Status.S22E)
+							.and()
+						.withStates()
+							.parent(Status.S2)
+							.initial(Status.S23I)
+							.state(Status.S23_IN_PROGRESS)
+							.state(Status.S23_PASSED)
+							.end(Status.S23E)
+							.and()
+						.withStates()
+							.parent(Status.S2)
+							.initial(Status.S24I)
+							.choice(Status.CHOICE_S24)
+							.state(Status.S24_IN_PROGRESS)
+							.state(Status.S24_PASSED)
+							.state(Status.S24_NOT_REQUIRED)
+							.end(Status.S24E);
+		}
+
+		@Override
+		public void configure(StateMachineTransitionConfigurer<Status, Event> transitions) throws Exception {
+			transitions
+                            .withExternal().source(Status.S0).target(Status.S1).event(Event.NEW).and()
+
+                            .withExternal().source(Status.S1).target(Status.FORK_S2).and()
+
+                            .withFork().source(Status.FORK_S2).target(Status.S2).and()
+
+                            .withExternal().source(Status.S21I).target(Status.S21_NOT_REQUIRED).event(Event.S21_NOT_REQUIRED)
+                            .and()
+
+                            .withExternal().source(Status.S21_NOT_REQUIRED).target(Status.S21E).and()
+
+                            .withExternal().source(Status.S22I).target(Status.S22_IN_PROGRESS).event(Event.S22_IN_PROGRESS)
+                            .and()
+
+                            .withExternal().source(Status.S22_IN_PROGRESS).target(Status.S22_PASSED).event(Event.S22_PASSED)
+                            .and()
+
+                            .withExternal().source(Status.S22_PASSED).target(Status.S22E).and()
+
+                            .withExternal().source(Status.S23I).target(Status.S23_IN_PROGRESS).and()
+
+                            .withExternal().source(Status.S23_IN_PROGRESS).target(Status.S23_PASSED).event(Event.S23_PASSED)
+                            .and()
+
+                            .withExternal().source(Status.S23_PASSED).target(Status.S23E).and()
+
+                            .withExternal().source(Status.S24I).target(Status.CHOICE_S24).and()
+
+                            .withChoice().source(Status.CHOICE_S24).first(Status.S24_IN_PROGRESS, ctx -> false)
+                            .last(Status.S24_NOT_REQUIRED).and()
+
+                            .withExternal().source(Status.S24_NOT_REQUIRED).target(Status.S24E).and()
+
+                            .withExternal().source(Status.S24_IN_PROGRESS).target(Status.S24_PASSED).event(Event.S24_PASSED)
+                            .and()
+
+                            .withExternal().source(Status.S24_PASSED).target(Status.S24E).and()
+
+                            .withJoin().source(Status.S2).target(Status.JOIN_S2).and()
+
+                            .withExternal().source(Status.JOIN_S2).target(Status.S3).guard(ctx -> true).and()
+
+                            .withExternal().source(Status.S3).target(Status.S4).guard(toggledVarTrue()).and()
+
+                            .withInternal().source(Status.ROOT).event(Event.TOGGLE_STATUS_0)
+                            .action(ctx -> ctx.getExtendedState().getVariables().put("toggle_status", "0")).and()
+
+                            .withInternal().source(Status.ROOT).event(Event.TOGGLE_STATUS_1)
+                            .action(ctx -> ctx.getExtendedState().getVariables().put("toggle_status", "1")).and()
+
+							.withExternal().source(Status.ROOT).target(Status.CLOSED).event(Event.CLOSE)
+
+			;
+		}
+
+		private Guard<Status, Event> toggledVarTrue() {
+			return context -> {
+				boolean guard = String.valueOf(context.getExtendedState().get("toggle_status", String.class))
+						.equalsIgnoreCase("1");
+				return guard;
+			};
+		}
+
+	}
+
+	public enum Status {
+		ROOT, CLOSED,
+		S0,
+		S1,
+		FORK_S2, S2, JOIN_S2,
+		S21I, S21_IN_PROGRESS, S21_NOT_REQUIRED, S21E,
+		S22I, S22_IN_PROGRESS, S22_PASSED, S22E,
+		S23I, S23_IN_PROGRESS, S23_PASSED, S23E,
+		S24I, S24_PASSED, S24_IN_PROGRESS, S24_NOT_REQUIRED, S24E, CHOICE_S24,
+		S4, S5, S3;
+	}
+
+	public enum Event {
+		NEW,
+		S21_NOT_REQUIRED,
+		S22_IN_PROGRESS, S22_PASSED,
+		S23_PASSED,
+		TOGGLE_STATUS_0, TOGGLE_STATUS_1, S24_PASSED,
+		CLOSE
+	}
+
+	@Override
+	protected AnnotationConfigApplicationContext buildContext() {
+		return new AnnotationConfigApplicationContext();
+	}
+}

--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/Gh737TestsPlus.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/Gh737TestsPlus.java
@@ -48,7 +48,7 @@ public class Gh737TestsPlus extends AbstractBuildTests {
 //		doStartAndAssert(machine);
 
 		StateMachineContext stateMachineContext = new DefaultStateMachineContext(Status.CLOSED, null, null, null, null, null);
-		machine.getStateMachineAccessor().doWithRegion(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
 
 		doSendEventAndConsumeAll(machine, Event.NEW);
 		assertThat(machine.getState().getIds(), containsInAnyOrder(Status.CLOSED));


### PR DESCRIPTION
As the test case shows: 

1) When I load a state machine from scratch, I started it after resetting the state machine based on the given context.
2) After I tried to send a NEW event outside of the nested ROOT state, I am expecting the NEW event would not be accepted. However, a NULL pointer is thrown as follows:

```
java.lang.NullPointerException
	at org.springframework.statemachine.support.AbstractStateMachine.resetStateMachine(AbstractStateMachine.java:807)
	at org.springframework.statemachine.buildtests.Gh737TestsPlus.lambda$test$0(Gh737TestsPlus.java:51)
	at org.springframework.statemachine.support.AbstractStateMachine$6.doWithAllRegions(AbstractStateMachine.java:544)
	at org.springframework.statemachine.support.AbstractStateMachine$6.doWithAllRegions(AbstractStateMachine.java:548)
	at org.springframework.statemachine.buildtests.Gh737TestsPlus.test(Gh737TestsPlus.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:40)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:71)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:220)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:188)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:202)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:181)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:102)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:82)
	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:78)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:61)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy2.stop(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.stop(TestWorker.java:132)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:175)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:157)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
	at java.lang.Thread.run(Thread.java:748)

org.springframework.statemachine.buildtests.Gh737TestsPlus > test FAILED
    java.lang.NullPointerException at Gh737TestsPlus.java:51
```
