### PR TITLE
Jpa eclipselink compability

### DIFF
--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryAction.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryAction.java
@@ -15,11 +15,7 @@
  */
 package org.springframework.statemachine.data.jpa;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.springframework.statemachine.data.RepositoryAction;
 
@@ -33,15 +29,19 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
-@Table(name = "Action")
-@JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
+@Table(name = "action")
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryAction extends RepositoryAction {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	private long id;
+	@Column(name = "id")
+	private Long id;
 
+	@Column(name = "name")
 	private String name;
+
+	@Column(name = "spel")
 	private String spel;
 
 	@Override

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryAction.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryAction.java
@@ -15,7 +15,12 @@
  */
 package org.springframework.statemachine.data.jpa;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Column;
 
 import org.springframework.statemachine.data.RepositoryAction;
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryGuard.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryGuard.java
@@ -15,7 +15,12 @@
  */
 package org.springframework.statemachine.data.jpa;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Column;
 
 import org.springframework.statemachine.data.RepositoryGuard;
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryGuard.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryGuard.java
@@ -15,11 +15,7 @@
  */
 package org.springframework.statemachine.data.jpa;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.springframework.statemachine.data.RepositoryGuard;
 
@@ -33,15 +29,19 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
-@Table(name = "Guard")
-@JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
+@Table(name = "guard")
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryGuard extends RepositoryGuard {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	private long id;
+	@Column(name = "id")
+	private Long id;
 
+	@Column(name = "name")
 	private String name;
+
+	@Column(name = "spel")
 	private String spel;
 
 	@Override

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryState.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryState.java
@@ -46,21 +46,30 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
-@Table(name = "State")
-@JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
+@Table(name = "state")
+@JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryState extends RepositoryState {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	private long id;
+	private Long id;
 
+	@Column(name = "machine_id")
 	private String machineId;
+
+	@Column(name = "state")
 	private String state;
+
+	@Column(name = "region")
 	private String region;
 
-	@Column(name = "initialState")
-	private boolean initial;
+	@Column(name = "initial_state")
+	private Boolean initial;
+
+	@Column(name = "kind")
 	private PseudoStateKind kind;
+
+	@Column(name = "submachine_id")
 	private String submachineId;
 
 	@OneToOne(fetch = FetchType.EAGER)
@@ -84,7 +93,7 @@ public class JpaRepositoryState extends RepositoryState {
 	private Set<JpaRepositoryAction> exitActions;
 
 	@ElementCollection(fetch = FetchType.EAGER, targetClass = String.class)
-	@CollectionTable(name="DeferredEvents", foreignKey = @ForeignKey(name = "fk_state_deferred_events"))
+	@CollectionTable(name = "deferred_events", foreignKey = @ForeignKey(name = "fk_state_deferred_events"))
 	private Set<String> deferredEvents;
 
 	/**
@@ -106,10 +115,10 @@ public class JpaRepositoryState extends RepositoryState {
 	/**
 	 * Instantiates a new jpa repository state.
 	 *
-	 * @param state the state
+	 * @param state   the state
 	 * @param initial the initial
 	 */
-	public JpaRepositoryState(String state, boolean initial) {
+	public JpaRepositoryState(String state, Boolean initial) {
 		this(null, state, initial);
 	}
 
@@ -117,38 +126,38 @@ public class JpaRepositoryState extends RepositoryState {
 	 * Instantiates a new jpa repository state.
 	 *
 	 * @param machineId the machine id
-	 * @param state the state
-	 * @param initial the initial
+	 * @param state     the state
+	 * @param initial   the initial
 	 */
-	public JpaRepositoryState(String machineId, String state, boolean initial) {
+	public JpaRepositoryState(String machineId, String state, Boolean initial) {
 		this(machineId, null, state, initial);
 	}
 
 	/**
 	 * Instantiates a new jpa repository state.
 	 *
-	 * @param machineId the machine id
+	 * @param machineId   the machine id
 	 * @param parentState the parent state
-	 * @param state the state
-	 * @param initial the initial
+	 * @param state       the state
+	 * @param initial     the initial
 	 */
-	public JpaRepositoryState(String machineId, JpaRepositoryState parentState, String state, boolean initial) {
+	public JpaRepositoryState(String machineId, JpaRepositoryState parentState, String state, Boolean initial) {
 		this(machineId, parentState, state, initial, null, null, null);
 	}
 
 	/**
 	 * Instantiates a new jpa repository state.
 	 *
-	 * @param machineId the machine id
-	 * @param parentState the parent state
-	 * @param state the state
-	 * @param initial the initial
+	 * @param machineId    the machine id
+	 * @param parentState  the parent state
+	 * @param state        the state
+	 * @param initial      the initial
 	 * @param stateActions the state actions
 	 * @param entryActions the entry actions
-	 * @param exitActions the exit actions
+	 * @param exitActions  the exit actions
 	 */
-	public JpaRepositoryState(String machineId, JpaRepositoryState parentState, String state, boolean initial, Set<JpaRepositoryAction> stateActions,
-			Set<JpaRepositoryAction> entryActions, Set<JpaRepositoryAction> exitActions) {
+	public JpaRepositoryState(String machineId, JpaRepositoryState parentState, String state, Boolean initial, Set<JpaRepositoryAction> stateActions,
+							  Set<JpaRepositoryAction> entryActions, Set<JpaRepositoryAction> exitActions) {
 		this.machineId = machineId == null ? "" : machineId;
 		this.parentState = parentState;
 		this.state = state;
@@ -204,11 +213,11 @@ public class JpaRepositoryState extends RepositoryState {
 	}
 
 	@Override
-	public boolean isInitial() {
+	public Boolean isInitial() {
 		return initial;
 	}
 
-	public void setInitial(boolean initial) {
+	public void setInitial(Boolean initial) {
 		this.initial = initial;
 	}
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachine.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachine.java
@@ -15,10 +15,7 @@
  */
 package org.springframework.statemachine.data.jpa;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Lob;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.springframework.statemachine.data.RepositoryStateMachine;
 
@@ -32,16 +29,19 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
-@Table(name = "StateMachine")
+@Table(name = "state_machine")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryStateMachine extends RepositoryStateMachine {
 
 	@Id
+	@Column(name = "machine_id")
 	private String machineId;
 
+	@Column(name = "state")
 	private String state;
 
 	@Lob
+	@Column(name = "state_machine_context")
 	private byte[] stateMachineContext;
 
 	@Override

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachine.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryStateMachine.java
@@ -15,7 +15,11 @@
  */
 package org.springframework.statemachine.data.jpa;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Column;
 
 import org.springframework.statemachine.data.RepositoryStateMachine;
 

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryTransition.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryTransition.java
@@ -17,17 +17,7 @@ package org.springframework.statemachine.data.jpa;
 
 import java.util.Set;
 
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.springframework.statemachine.data.RepositoryTransition;
 import org.springframework.statemachine.transition.TransitionKind;
@@ -42,14 +32,16 @@ import com.fasterxml.jackson.annotation.ObjectIdGenerators;
  *
  */
 @Entity
-@Table(name = "Transition")
+@Table(name = "transition")
 @JsonIdentityInfo(generator=ObjectIdGenerators.IntSequenceGenerator.class)
 public class JpaRepositoryTransition extends RepositoryTransition {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.AUTO)
-	private long id;
+	@Column(name = "id")
+	private Long id;
 
+	@Column(name = "machine_id")
 	private String machineId;
 
 	@OneToOne(fetch = FetchType.EAGER)
@@ -60,7 +52,10 @@ public class JpaRepositoryTransition extends RepositoryTransition {
 	@JoinColumn(foreignKey = @ForeignKey(name = "fk_transition_target"))
 	private JpaRepositoryState target;
 
+	@Column(name = "event")
 	private String event;
+
+	@Column(name = "kind")
 	private TransitionKind kind;
 
 	@ManyToMany(fetch = FetchType.EAGER)

--- a/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryTransition.java
+++ b/spring-statemachine-data/jpa/src/main/java/org/springframework/statemachine/data/jpa/JpaRepositoryTransition.java
@@ -17,7 +17,18 @@ package org.springframework.statemachine.data.jpa;
 
 import java.util.Set;
 
-import javax.persistence.*;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Column;
+import javax.persistence.OneToOne;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ForeignKey;
+import javax.persistence.ManyToMany;
+import javax.persistence.JoinTable;
 
 import org.springframework.statemachine.data.RepositoryTransition;
 import org.springframework.statemachine.transition.TransitionKind;

--- a/spring-statemachine-data/mongodb/src/main/java/org/springframework/statemachine/data/mongodb/MongoDbRepositoryState.java
+++ b/spring-statemachine-data/mongodb/src/main/java/org/springframework/statemachine/data/mongodb/MongoDbRepositoryState.java
@@ -180,7 +180,7 @@ public class MongoDbRepositoryState extends RepositoryState {
 	}
 
 	@Override
-	public boolean isInitial() {
+	public Boolean isInitial() {
 		return initial;
 	}
 

--- a/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisRepositoryState.java
+++ b/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisRepositoryState.java
@@ -190,7 +190,7 @@ public class RedisRepositoryState extends RepositoryState {
 	}
 
 	@Override
-	public boolean isInitial() {
+	public Boolean isInitial() {
 		return initial;
 	}
 

--- a/spring-statemachine-data/src/main/java/org/springframework/statemachine/data/RepositoryState.java
+++ b/spring-statemachine-data/src/main/java/org/springframework/statemachine/data/RepositoryState.java
@@ -60,7 +60,7 @@ public abstract class RepositoryState extends BaseRepositoryEntity {
 	 *
 	 * @return true, if is initial
 	 */
-	public abstract boolean isInitial();
+	public abstract Boolean isInitial();
 
 	/**
 	 * Gets the initial action. This is any meaningful if


### PR DESCRIPTION
With this change, Eclipselink support is added to SSM. To do this, table names are modified and some primitive types are changed to object types.