### PR TITLE
Add generic, thread safe support to PersistStateMachineHandler

### DIFF
--- a/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/AbstractPersistStateMachineHandler.java
+++ b/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/AbstractPersistStateMachineHandler.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.recipes.persist;
+
+import org.springframework.messaging.Message;
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.access.StateMachineAccess;
+import org.springframework.statemachine.listener.AbstractCompositeListener;
+import org.springframework.statemachine.state.State;
+import org.springframework.statemachine.support.DefaultStateMachineContext;
+import org.springframework.statemachine.support.LifecycleObjectSupport;
+import org.springframework.statemachine.support.StateMachineInterceptorAdapter;
+import org.springframework.statemachine.transition.Transition;
+import reactor.core.publisher.Mono;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * {@code AbstractPersistStateMachineHandler} is a base recipe which can be used to
+ * handle a state change of an arbitrary entity in a persistent storage.
+ *
+ * @author Janne Valkealahti
+ */
+public abstract class AbstractPersistStateMachineHandler<S, E> extends LifecycleObjectSupport {
+
+    protected final PersistingStateChangeInterceptor interceptor = new PersistingStateChangeInterceptor();
+    protected final CompositePersistStateChangeListener listeners = new CompositePersistStateChangeListener();
+
+    protected abstract StateMachine<S, E> getInitStateMachine();
+
+    protected void initStateMachine(StateMachine<S, E> stateMachine) {
+        List<StateMachineAccess<S, E>> withAllRegions = stateMachine.getStateMachineAccessor().withAllRegions();
+        for (StateMachineAccess<S, E> a : withAllRegions) {
+            a.addStateMachineInterceptor(interceptor);
+        }
+    }
+
+    /**
+     * Handle event with entity.
+     *
+     * @param event the event
+     * @param state the state
+     * @return true if event was accepted
+     * @see #handleEventWithStateReactively(Message, S)
+     */
+    @Deprecated
+    public boolean handleEventWithState(Message<E> event, S state) {
+        StateMachine<S, E> stateMachine = getInitStateMachine();
+        stateMachine.stopReactively().block();
+        List<StateMachineAccess<S, E>> withAllRegions = stateMachine.getStateMachineAccessor().withAllRegions();
+        for (StateMachineAccess<S, E> a : withAllRegions) {
+            a.resetStateMachine(new DefaultStateMachineContext<S, E>(state, null, null, null));
+        }
+        stateMachine.startReactively().block();
+        return stateMachine.sendEvent(event);
+    }
+
+    /**
+     * Handle event with entity reactively.
+     *
+     * @param event the event
+     * @param state the state
+     * @return mono for completion
+     */
+    public Mono<Void> handleEventWithStateReactively(Message<E> event, S state) {
+        StateMachine<S, E> stateMachine = getInitStateMachine();
+        // TODO: REACTOR add docs and revisit this function concept
+        return Mono.from(stateMachine.stopReactively())
+                .then(Mono.fromRunnable(() -> {
+                    List<StateMachineAccess<S, E>> withAllRegions = stateMachine.getStateMachineAccessor().withAllRegions();
+                    for (StateMachineAccess<S, E> a : withAllRegions) {
+                        a.resetStateMachine(new DefaultStateMachineContext<S, E>(state, null, null, null));
+                    }
+                }))
+                .then(stateMachine.startReactively())
+                .thenMany(stateMachine.sendEvent(Mono.just(event)))
+                .then();
+    }
+
+    /**
+     * Adds the persist state change listener.
+     *
+     * @param listener the listener
+     */
+    public void addPersistStateChangeListener(GenericPersistStateChangeListener<S, E> listener) {
+        listeners.register(listener);
+    }
+
+    /**
+     * The listener interface for receiving persistStateChange events.
+     * The class that is interested in processing a persistStateChange
+     * event implements this interface, and the object created
+     * with that class is registered with a component using the
+     * component's <code>addPersistStateChangeListener</code> method. When
+     * the persistStateChange event occurs, that object's appropriate
+     * method is invoked.
+     */
+    public interface GenericPersistStateChangeListener<S, E> {
+
+        /**
+         * Called when state needs to be persisted.
+         *
+         * @param state        the state
+         * @param message      the message
+         * @param transition   the transition
+         * @param stateMachine the state machine
+         */
+        void onPersist(State<S, E> state, Message<E> message, Transition<S, E> transition,
+                       StateMachine<S, E> stateMachine);
+    }
+
+    private class PersistingStateChangeInterceptor extends StateMachineInterceptorAdapter<S, E> {
+
+        @Override
+        public void preStateChange(State<S, E> state, Message<E> message,
+                                   Transition<S, E> transition, StateMachine<S, E> stateMachine,
+                                   StateMachine<S, E> rootStateMachine) {
+            listeners.onPersist(state, message, transition, stateMachine);
+        }
+    }
+
+    private class CompositePersistStateChangeListener extends AbstractCompositeListener<GenericPersistStateChangeListener<S, E>> implements
+            GenericPersistStateChangeListener<S, E> {
+
+        @Override
+        public void onPersist(State<S, E> state, Message<E> message,
+                              Transition<S, E> transition, StateMachine<S, E> stateMachine) {
+            for (Iterator<GenericPersistStateChangeListener<S, E>> iterator = getListeners().reverse(); iterator.hasNext(); ) {
+                GenericPersistStateChangeListener<S, E> listener = iterator.next();
+                listener.onPersist(state, message, transition, stateMachine);
+            }
+        }
+    }
+
+}

--- a/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/FactoryPersistStateMachineHandler.java
+++ b/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/FactoryPersistStateMachineHandler.java
@@ -1,0 +1,50 @@
+package org.springframework.statemachine.recipes.persist;
+
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineException;
+import org.springframework.statemachine.config.StateMachineBuilder;
+import org.springframework.statemachine.config.StateMachineFactory;
+import org.springframework.util.Assert;
+
+/**
+ * {@code FactoryPersistStateMachineHandler} is a recipe can be used to
+ * handle a state change of an arbitrary entity in a persistent storage.
+ * <br>
+ * This implementation accepts {@link StateMachineFactory}
+ * or {@link StateMachineBuilder.Builder} to provide thread safe feature
+ * without sharing same state machine in concurrent environment.
+ * New state machine will be created when handling method is called.
+ *
+ * @author Ng Zouyiu
+ */
+public class FactoryPersistStateMachineHandler<S, E> extends AbstractPersistStateMachineHandler<S, E> {
+
+    protected final StateMachineFactory<S, E> factory;
+    protected final StateMachineBuilder.Builder<S, E> builder;
+
+    public FactoryPersistStateMachineHandler(StateMachineBuilder.Builder<S, E> builder) {
+        Assert.notNull(builder, "State machine builder must be set");
+        this.builder = builder;
+        factory = null;
+    }
+
+    public FactoryPersistStateMachineHandler(StateMachineFactory<S, E> factory) {
+        Assert.notNull(factory, "State machine factory must be set");
+        this.factory = factory;
+        builder = null;
+    }
+
+    @Override
+    protected StateMachine<S, E> getInitStateMachine() {
+        StateMachine<S, E> stateMachine;
+        if (factory != null) {
+            stateMachine = factory.getStateMachine();
+        } else if (builder != null) {
+            stateMachine = builder.build();
+        } else {
+            throw new StateMachineException("Factory or builder must be set to build state machine for handler");
+        }
+        initStateMachine(stateMachine);
+        return stateMachine;
+    }
+}

--- a/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/GenericPersistStateMachineHandler.java
+++ b/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/GenericPersistStateMachineHandler.java
@@ -16,9 +16,10 @@
 package org.springframework.statemachine.recipes.persist;
 
 import org.springframework.statemachine.StateMachine;
+import org.springframework.util.Assert;
 
 /**
- * {@code PersistStateMachineHandler} is a recipe which can be used to
+ * {@code GenericPersistStateMachineHandler} is a recipe which can be used to
  * handle a state change of an arbitrary entity in a persistent storage.
  * <br>
  * For concurrent usage, please consider using {@link FactoryPersistStateMachineHandler}
@@ -26,13 +27,27 @@ import org.springframework.statemachine.StateMachine;
  *
  * @author Janne Valkealahti
  */
-public class PersistStateMachineHandler extends GenericPersistStateMachineHandler<String, String> {
+public class GenericPersistStateMachineHandler<S, E> extends AbstractPersistStateMachineHandler<S, E> {
 
-    public PersistStateMachineHandler(StateMachine<String, String> stateMachine) {
-        super(stateMachine);
+    protected final StateMachine<S, E> stateMachine;
+
+    /**
+     * Instantiates a new persist state machine handler.
+     *
+     * @param stateMachine the state machine
+     */
+    public GenericPersistStateMachineHandler(StateMachine<S, E> stateMachine) {
+        Assert.notNull(stateMachine, "State machine must be set");
+        this.stateMachine = stateMachine;
     }
 
-    public interface PersistStateChangeListener extends GenericPersistStateChangeListener<String, String> {
+    @Override
+    protected void onInit() throws Exception {
+        initStateMachine(stateMachine);
     }
 
+    @Override
+    protected StateMachine<S, E> getInitStateMachine() {
+        return stateMachine;
+    }
 }


### PR DESCRIPTION
The original `PersistStateMachineHandler` is not thread safe due to codes below is not synchronized:
https://github.com/spring-projects/spring-statemachine/blob/3c38675eb031bc094602a9181d2c1f8074d2b4dc/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/persist/PersistStateMachineHandler.java#L71-L79

The solution from this PR is accepting a factory/builder to create new state machine when event and state need to be handled, no more sharing same machine between threads. This solution maybe slow down the process of handling however solves concurrent problem successfully.

Besides, generic version of `PersistStateMachineHandler` is added so that enum states, events can be easier to used.