### PR TITLE
Pass error from executor

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachineSystemConstants.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachineSystemConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,4 +34,7 @@ public abstract class StateMachineSystemConstants {
 
 	/** State machine id key for headers and variables */
 	public static final String STATEMACHINE_IDENTIFIER = "_sm_id_";
+
+	/** Contstant storing errors in a reactor context */
+	public static final String REACTOR_CONTEXT_ERRORS = "stateMachineErrors";
 }

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/EventSecurityTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/security/EventSecurityTests.java
@@ -43,7 +43,7 @@ public class EventSecurityTests extends AbstractSecurityTests {
 	public void testEventDeniedViaExpression() throws Exception {
 		TestListener listener = new TestListener();
 		StateMachine<States, Events> machine = buildMachine(listener, null, null, null, null, null, "false");
-		assertTransitionDenied(machine, listener);
+		assertTransitionDeniedResultAsDenied(machine, listener);
 	}
 
 	@Test
@@ -51,7 +51,7 @@ public class EventSecurityTests extends AbstractSecurityTests {
 	public void testEventDeniedViaAttributes() throws Exception {
 		TestListener listener = new TestListener();
 		StateMachine<States, Events> machine = buildMachine(listener, null, null, null, "EVENT_B", ComparisonType.ALL, null);
-		assertTransitionDenied(machine, listener);
+		assertTransitionDeniedResultAsDenied(machine, listener);
 	}
 
 	@Test


### PR DESCRIPTION
- New concept of using callback to pass on error as
  things can't be properly propagated as we're manually
  dispatching to processor.
- Relates #821