### PR TITLE
Change machine reset to reactive

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/access/ReactiveStateMachineAccess.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/access/ReactiveStateMachineAccess.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.statemachine.access;
+
+import org.springframework.statemachine.StateMachine;
+import org.springframework.statemachine.StateMachineContext;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Functional interface exposing reactive {@link StateMachine} internals.
+ *
+ * @author Janne Valkealahti
+ *
+ * @param <S> the type of state
+ * @param <E> the type of event
+ */
+public interface ReactiveStateMachineAccess<S, E> {
+
+	/**
+	 * Reset state machine reactively.
+	 *
+	 * @param stateMachineContext the state machine context
+	 * @return mono for completion
+	 */
+	Mono<Void> resetStateMachineReactively(StateMachineContext<S, E> stateMachineContext);
+}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/access/StateMachineAccess.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/access/StateMachineAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.statemachine.support.StateMachineInterceptor;
  * @param <S> the type of state
  * @param <E> the type of event
  */
-public interface StateMachineAccess<S, E> {
+public interface StateMachineAccess<S, E> extends ReactiveStateMachineAccess<S, E> {
 
 	/**
 	 * Sets the relay state machine.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/access/StateMachineAccessTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/access/StateMachineAccessTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,11 @@ public class StateMachineAccessTests {
 
 		@Override
 		public void resetStateMachine(StateMachineContext<String, String> stateMachineContext) {
+		}
+
+		@Override
+		public Mono<Void> resetStateMachineReactively(StateMachineContext<String, String> stateMachineContext) {
+			return Mono.empty();
 		}
 
 		@Override


### PR DESCRIPTION
- Re-implement resetStateMachineReactively as fully reactive
  chain by following same logic as in blocking version.
- New interface ReactiveStateMachineAccess as we need to
  know if one need to call reactive method.
- Fixes #911