### PR TITLE
Replace resetStateMachine with resetStateMachineReactively

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/access/StateMachineAccess.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/access/StateMachineAccess.java
@@ -42,7 +42,9 @@ public interface StateMachineAccess<S, E> extends ReactiveStateMachineAccess<S, 
 	 * Reset state machine.
 	 *
 	 * @param stateMachineContext the state machine context
+	 * @see #resetStateMachineReactively(StateMachineContext)
 	 */
+	@Deprecated
 	void resetStateMachine(StateMachineContext<S, E> stateMachineContext);
 
 	/**

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/ensemble/DistributedStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/ensemble/DistributedStateMachine.java
@@ -296,7 +296,7 @@ public class DistributedStateMachine<S, E> extends LifecycleObjectSupport implem
 						log.debug("Joining with context " + context);
 					}
 
-					delegate.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(context));
+					delegate.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(context).block());
 				}
 				log.info("Requesting to start delegating state machine " + delegate);
 				log.info("Delegating machine id " + delegate.getUuid());

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/AbstractStateMachinePersister.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/persist/AbstractStateMachinePersister.java
@@ -67,7 +67,7 @@ public abstract class AbstractStateMachinePersister<S, E, T> implements StateMac
 	public final StateMachine<S, E> restore(StateMachine<S, E> stateMachine, T contextObj) throws Exception {
 		final StateMachineContext<S, E> context = stateMachinePersist.read(contextObj);
 		stateMachine.stopReactively().block();
-		stateMachine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(context));
+		stateMachine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(context).block());
 		stateMachine.startReactively().block();
 		return stateMachine;
 	}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/service/DefaultStateMachineService.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/service/DefaultStateMachineService.java
@@ -166,7 +166,7 @@ public class DefaultStateMachineService<S, E> implements StateMachineService<S, 
 		}
 		stateMachine.stopReactively().block();
 		// only go via top region
-		stateMachine.getStateMachineAccessor().doWithRegion(function -> function.resetStateMachine(stateMachineContext));
+		stateMachine.getStateMachineAccessor().doWithRegion(function -> function.resetStateMachineReactively(stateMachineContext).block());
 		return stateMachine;
 	}
 

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
@@ -77,7 +77,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		ExtendedState extendedState = new DefaultExtendedState(variables);
 		DefaultStateMachineContext<States,Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S12, Events.I, null, extendedState);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(States.S0, States.S1, States.S12);
@@ -95,7 +95,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		ExtendedState extendedState = new DefaultExtendedState(variables);
 		DefaultStateMachineContext<States,Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S211, Events.C, null, extendedState);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(States.S0, States.S2, States.S21, States.S211);
@@ -113,7 +113,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		ExtendedState extendedState = new DefaultExtendedState(variables);
 		DefaultStateMachineContext<States,Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S2, Events.C, null, extendedState);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(States.S0, States.S2, States.S21, States.S211);
@@ -138,7 +138,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		DefaultStateMachineContext<TestStates, TestEvents> stateMachineContext =
 				new DefaultStateMachineContext<TestStates, TestEvents>(childs, TestStates.S2, TestEvents.E1, null, null);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(TestStates.S2, TestStates.S21, TestStates.S31);
@@ -162,7 +162,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		DefaultStateMachineContext<TestStates, TestEvents> stateMachineContext =
 				new DefaultStateMachineContext<TestStates, TestEvents>(childs, TestStates.S2, null, null, null);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(TestStates.S2, TestStates.S21, TestStates.S31);
@@ -184,7 +184,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		ExtendedState extendedState = new DefaultExtendedState(variables);
 		DefaultStateMachineContext<States,Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S0, null, null, extendedState);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count")).isEqualTo(1);
@@ -207,7 +207,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		assertThat((Integer)machine.getExtendedState().getVariables().get("foo")).isZero();
 
 		doStopAndAssert(machine);
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(null));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(null).block());
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(States.S0, States.S1, States.S11);
 		assertThat(machine.getExtendedState().getVariables()).isEmpty();
@@ -229,7 +229,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		DefaultStateMachineContext<States, Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(
 				States.S11, null, null, null);
 		machine.getStateMachineAccessor()
-				.doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+				.doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(States.S0, States.S1, States.S11);
@@ -246,7 +246,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 
 		DefaultStateMachineContext<States, Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S1, null,
 				null, null);
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		Thread.sleep(1100);
@@ -290,7 +290,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		ExtendedState extendedState = new DefaultExtendedState(variables);
 		DefaultStateMachineContext<States,Events> stateMachineContext = new DefaultStateMachineContext<States, Events>(States.S0, null, null, extendedState);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 		doStartAndAssert(machine);
 
 		assertThat((Integer)machine.getExtendedState().getVariables().get("count1")).isEqualTo(1);
@@ -321,7 +321,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		DefaultStateMachineContext<MyState, MyEvent> stateMachineContext = new DefaultStateMachineContext<MyState, MyEvent>(
 				SubState.SUB_NEXT, null, null, null);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(SuperState.PARENT, SubState.SUB_NEXT);
@@ -337,7 +337,7 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		DefaultStateMachineContext<MyState, MyEvent> stateMachineContext = new DefaultStateMachineContext<MyState, MyEvent>(
 				SuperState.INITIAL, null, null, null);
 
-		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(stateMachineContext));
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
 
 		doStartAndAssert(machine);
 		assertThat(machine.getState().getIds()).containsOnly(SuperState.INITIAL);

--- a/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/tasks/TasksHandler.java
+++ b/spring-statemachine-recipes/src/main/java/org/springframework/statemachine/recipes/tasks/TasksHandler.java
@@ -166,7 +166,7 @@ public class TasksHandler {
 		}
 
 		stateMachine.stopReactively().block();
-		stateMachine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachine(context));
+		stateMachine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(context).block());
 		stateMachine.startReactively().block();
 	}
 


### PR DESCRIPTION
Fix #949

1. Marked `resetStateMachine` as deprecated and replace `resetStateMachine()` calls to `resetStateMachineReactively().block()`.
2. Introduced `Mono#defer` to `AbstractPersistStateMachineHandler#handleEventWithStateReactively` for initialing the state machine lazily.