### PR TITLE
Implement named transitions (fix #850)

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/AbstractStateMachineFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -886,7 +886,7 @@ public abstract class AbstractStateMachineFactory<S, E> extends LifecycleObjectS
 				}
 				DefaultExternalTransition<S, E> transition = new DefaultExternalTransition<S, E>(stateMap.get(source),
 						stateMap.get(target), transitionData.getActions(), event, transitionData.getGuard(), trigger,
-						transitionData.getSecurityRule());
+						transitionData.getSecurityRule(), transitionData.getName());
 				transitions.add(transition);
 
 			} else if (transitionData.getKind() == TransitionKind.LOCAL) {
@@ -896,12 +896,12 @@ public abstract class AbstractStateMachineFactory<S, E> extends LifecycleObjectS
 				}
 				DefaultLocalTransition<S, E> transition = new DefaultLocalTransition<S, E>(stateMap.get(source),
 						stateMap.get(target), transitionData.getActions(), event, transitionData.getGuard(), trigger,
-						transitionData.getSecurityRule());
+						transitionData.getSecurityRule(), transitionData.getName());
 				transitions.add(transition);
 			} else if (transitionData.getKind() == TransitionKind.INTERNAL) {
 				DefaultInternalTransition<S, E> transition = new DefaultInternalTransition<S, E>(stateMap.get(source),
 						transitionData.getActions(), event, transitionData.getGuard(), trigger,
-						transitionData.getSecurityRule());
+						transitionData.getSecurityRule(), transitionData.getName());
 				transitions.add(transition);
 			}
 		}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineTransitionBuilder.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineTransitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -176,14 +176,14 @@ public class StateMachineTransitionBuilder<S, E>
 	 * @param securityRule the security rule
 	 */
 	public void addTransition(S source, S target, S state, E event, Long period, Integer count, Collection<Action<S, E>> actions,
-			Guard<S, E> guard, TransitionKind kind, SecurityRule securityRule) {
+			Guard<S, E> guard, TransitionKind kind, SecurityRule securityRule, String name) {
 		// if rule not given, get it from global
 		if (securityRule == null) {
 			@SuppressWarnings("unchecked")
 			ConfigurationData<S, E> config = getSharedObject(ConfigurationData.class);
 			securityRule = config.getTransitionSecurityRule();
 		}
-		transitionData.add(new TransitionData<>(source, target, state, event, period, count, actions, guard, kind, securityRule));
+		transitionData.add(new TransitionData<>(source, target, state, event, period, count, actions, guard, kind, securityRule, name));
 	}
 
 	/**

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/AbstractTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/AbstractTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public abstract class AbstractTransitionConfigurer<S, E> extends
 	private final Collection<Action<S, E>> actions = new ArrayList<>();
 	private Guard<S, E> guard;
 	private SecurityRule securityRule;
+	private String name;
 
 	protected S getSource() {
 		return source;
@@ -87,6 +88,10 @@ public abstract class AbstractTransitionConfigurer<S, E> extends
 
 	protected SecurityRule getSecurityRule() {
 		return securityRule;
+	}
+	
+	protected String getName() {
+		return name;
 	}
 
 	protected void setSource(S source) {
@@ -141,6 +146,10 @@ public abstract class AbstractTransitionConfigurer<S, E> extends
 			securityRule = new SecurityRule();
 		}
 		securityRule.setExpression(expression);
+	}
+	
+	protected void setName(String name) {
+		this.name = name;
 	}
 
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultExternalTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultExternalTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class DefaultExternalTransitionConfigurer<S, E> extends AbstractTransitio
 	@Override
 	public void configure(StateMachineTransitionBuilder<S, E> builder) throws Exception {
 		builder.addTransition(getSource(), getTarget(), getState(), getEvent(), getPeriod(), getCount(), getActions(), getGuard(), TransitionKind.EXTERNAL,
-				getSecurityRule());
+				getSecurityRule(), getName());
 	}
 
 	@Override
@@ -113,6 +113,12 @@ public class DefaultExternalTransitionConfigurer<S, E> extends AbstractTransitio
 	@Override
 	public ExternalTransitionConfigurer<S, E> secured(String expression) {
 		setSecurityRule(expression);
+		return this;
+	}
+
+	@Override
+	public ExternalTransitionConfigurer<S, E> name(String name) {
+		setName(name);
 		return this;
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultInternalTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultInternalTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class DefaultInternalTransitionConfigurer<S, E> extends AbstractTransitio
 	@Override
 	public void configure(StateMachineTransitionBuilder<S, E> builder) throws Exception {
 		builder.addTransition(getSource(), getTarget(), getState(), getEvent(), getPeriod(), getCount(), getActions(), getGuard(), TransitionKind.INTERNAL,
-				getSecurityRule());
+				getSecurityRule(), getName());
 	}
 
 	@Override
@@ -107,6 +107,12 @@ public class DefaultInternalTransitionConfigurer<S, E> extends AbstractTransitio
 	@Override
 	public InternalTransitionConfigurer<S, E> secured(String expression) {
 		setSecurityRule(expression);
+		return this;
+	}
+
+	@Override
+	public InternalTransitionConfigurer<S, E> name(String name) {
+		setName(name);
 		return this;
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultLocalTransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultLocalTransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class DefaultLocalTransitionConfigurer<S, E> extends AbstractTransitionCo
 	@Override
 	public void configure(StateMachineTransitionBuilder<S, E> builder) throws Exception {
 		builder.addTransition(getSource(), getTarget(), getState(), getEvent(), getPeriod(), getCount(), getActions(), getGuard(), TransitionKind.LOCAL,
-				getSecurityRule());
+				getSecurityRule(), getName());
 	}
 
 	@Override
@@ -112,6 +112,12 @@ public class DefaultLocalTransitionConfigurer<S, E> extends AbstractTransitionCo
 	@Override
 	public LocalTransitionConfigurer<S, E> secured(String expression) {
 		setSecurityRule(expression);
+		return this;
+	}
+	
+	@Override
+	public LocalTransitionConfigurer<S, E> name(String name) {
+		setName(name);
 		return this;
 	}
 

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/TransitionConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/TransitionConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,4 +126,13 @@ public interface TransitionConfigurer<T, S, E> extends
 	 */
 	T secured(String expression);
 
+	/**
+	 * Specify a name for this {@link Transition}.
+	 * 
+	 * @param name the name
+	 * @return configurer for chaining
+	 * @param name
+	 * @return
+	 */
+	T name(String name);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/TransitionData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/TransitionData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class TransitionData<S, E> {
 	private final Guard<S, E> guard;
 	private final TransitionKind kind;
 	private final SecurityRule securityRule;
+	private final String name;
 
 	/**
 	 * Instantiates a new transition data.
@@ -48,7 +49,7 @@ public class TransitionData<S, E> {
 	 * @param event the event
 	 */
 	public TransitionData(S source, S target, E event) {
-		this(source, target, null, event, null, null, null, null, TransitionKind.EXTERNAL, null);
+		this(source, target, null, event, null, null, null, null, TransitionKind.EXTERNAL, null, null);
 	}
 
 	/**
@@ -63,7 +64,23 @@ public class TransitionData<S, E> {
 	 */
 	public TransitionData(S source, S target, E event, Collection<Action<S, E>> actions,
 			Guard<S, E> guard, TransitionKind kind) {
-		this(source, target, null, event, null, null, actions, guard, kind, null);
+		this(source, target, null, event, null, null, actions, guard, kind, null, null);
+	}
+	
+	/**
+	 * Instantiates a new transition data.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param event the event
+	 * @param actions the actions
+	 * @param guard the guard
+	 * @param kind the kind
+	 * @param name the name
+	 */
+	public TransitionData(S source, S target, E event, Collection<Action<S, E>> actions,
+			Guard<S, E> guard, TransitionKind kind, String name) {
+		this(source, target, null, event, null, null, actions, guard, kind, null, name);
 	}
 
 	/**
@@ -79,7 +96,41 @@ public class TransitionData<S, E> {
 	 */
 	public TransitionData(S source, S target, Long period, Integer count, Collection<Action<S, E>> actions,
 			Guard<S, E> guard, TransitionKind kind) {
-		this(source, target, null, null, period, count, actions, guard, kind, null);
+		this(source, target, null, null, period, count, actions, guard, kind, null, null);
+	}
+	
+	/**
+	 * Instantiates a new transition data.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param period the period
+	 * @param count the count
+	 * @param actions the actions
+	 * @param guard the guard
+	 * @param kind the kind
+	 * @param name the name
+	 */
+	public TransitionData(S source, S target, Long period, Integer count, Collection<Action<S, E>> actions,
+			Guard<S, E> guard, TransitionKind kind, String name) {
+		this(source, target, null, null, period, count, actions, guard, kind, null, name);
+	}
+	
+	/**
+	 * Instantiates a new transition data.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param period the period
+	 * @param count the count
+	 * @param actions the actions
+	 * @param guard the guard
+	 * @param kind the kind
+	 * @param securityRule the security rule
+	 */
+	public TransitionData(S source, S target, Long period, Integer count, Collection<Action<S, E>> actions,
+			Guard<S, E> guard, TransitionKind kind, SecurityRule securityRule) {
+		this(source, target, null, null, period, count, actions, guard, kind, securityRule, null);
 	}
 
 	/**
@@ -95,9 +146,10 @@ public class TransitionData<S, E> {
 	 * @param guard the guard
 	 * @param kind the kind
 	 * @param securityRule the security rule
+	 * @param name the name
 	 */
 	public TransitionData(S source, S target, S state, E event, Long period, Integer count, Collection<Action<S, E>> actions,
-			Guard<S, E> guard, TransitionKind kind, SecurityRule securityRule) {
+			Guard<S, E> guard, TransitionKind kind, SecurityRule securityRule, String name) {
 		this.source = source;
 		this.target = target;
 		this.state = state;
@@ -108,6 +160,7 @@ public class TransitionData<S, E> {
 		this.guard = guard;
 		this.kind = kind;
 		this.securityRule = securityRule;
+		this.name = (name == null) ? "" : name;
 	}
 
 	/**
@@ -198,5 +251,9 @@ public class TransitionData<S, E> {
 	 */
 	public SecurityRule getSecurityRule() {
 		return securityRule;
+	}
+	
+	public String getName() {
+		return name;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractExternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractExternalTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,23 @@ import java.util.Collection;
 
 public abstract class AbstractExternalTransition<S, E> extends AbstractTransition<S, E> implements Transition<S, E> {
 
+	/**
+	 * Instantiates a new abstract external transition.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param actions the actions
+	 * @param event the event
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 * @param securityRule the security rule
+	 * @param name the name
+	 */
+	public AbstractExternalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions,
+			E event, Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule, String name) {
+		super(source, target, actions, event, TransitionKind.EXTERNAL, guard, trigger, securityRule, name);
+	}
+	
 	/**
 	 * Instantiates a new abstract external transition.
 	 *

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractInternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractInternalTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,5 +52,21 @@ public class AbstractInternalTransition<S, E> extends AbstractTransition<S, E> i
 	public AbstractInternalTransition(State<S, E> source, Collection<Action<S, E>> actions, E event, Guard<S, E> guard,
 			Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, source, actions, event, TransitionKind.INTERNAL, guard, trigger, securityRule);
+	}
+	
+	/**
+	 * Instantiates a new abstract internal transition.
+	 *
+	 * @param source the source
+	 * @param actions the actions
+	 * @param event the event
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 * @param securityRule the security rule
+	 * @param name the name
+	 */
+	public AbstractInternalTransition(State<S, E> source, Collection<Action<S, E>> actions, E event, Guard<S, E> guard,
+			Trigger<S, E> trigger, SecurityRule securityRule, String name) {
+		super(source, source, actions, event, TransitionKind.INTERNAL, guard, trigger, securityRule, name);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractLocalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractLocalTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,5 +54,22 @@ public class AbstractLocalTransition<S, E> extends AbstractTransition<S, E> impl
 	public AbstractLocalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event,
 			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, TransitionKind.LOCAL, guard, trigger, securityRule);
+	}
+	
+	/**
+	 * Instantiates a new abstract local transition.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param actions the actions
+	 * @param event the event
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 * @param securityRule the security rule
+	 * @param name the name
+	 */
+	public AbstractLocalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event,
+			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule, String name) {
+		super(source, target, actions, event, TransitionKind.LOCAL, guard, trigger, securityRule, name);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/AbstractTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 	private final Guard<S, E> guard;
 	private final Trigger<S, E> trigger;
 	private final SecurityRule securityRule;
+	private final String name;
 	private CompositeActionListener<S, E> actionListener;
 
 	/**
@@ -62,7 +63,23 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 	 */
 	public AbstractTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event, TransitionKind kind,
 			Guard<S, E> guard, Trigger<S, E> trigger) {
-		this(source, target, actions, event, kind, guard, trigger, null);
+		this(source, target, actions, event, kind, guard, trigger, null, null);
+	}
+	
+	/**
+	 * Instantiates a new abstract transition.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param actions the actions
+	 * @param event the event
+	 * @param kind the kind
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 */
+	public AbstractTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event, TransitionKind kind,
+			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
+		this(source, target, actions, event, kind, guard, trigger, securityRule, null);
 	}
 
 	/**
@@ -78,7 +95,7 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 	 * @param securityRule the security rule
 	 */
 	public AbstractTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event, TransitionKind kind,
-			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
+			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule, String name) {
 		Assert.notNull(kind, "Transition type must be set");
 		this.source = source;
 		this.target = target;
@@ -87,6 +104,7 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 		this.guard = guard;
 		this.trigger = trigger;
 		this.securityRule = securityRule;
+		this.name = (name == null) ? "" : name;
 	}
 
 	@Override
@@ -133,6 +151,11 @@ public abstract class AbstractTransition<S, E> implements Transition<S, E> {
 	@Override
 	public State<S, E> getTarget() {
 		return target;
+	}
+	
+	@Override
+	public String getName() {
+		return name;
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultExternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultExternalTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class DefaultExternalTransition<S, E> extends AbstractExternalTransition<
 			Guard<S, E> guard, Trigger<S, E> trigger) {
 		super(source, target, actions, event, guard, trigger);
 	}
-
+	
 	/**
 	 * Instantiates a new default external transition.
 	 *
@@ -54,5 +54,22 @@ public class DefaultExternalTransition<S, E> extends AbstractExternalTransition<
 	public DefaultExternalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event,
 			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, guard, trigger, securityRule);
+	}
+
+	/**
+	 * Instantiates a new default external transition.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param actions the actions
+	 * @param event the event
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 * @param securityRule the security rule
+	 * @param name the name
+	 */
+	public DefaultExternalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event,
+			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule, String name) {
+		super(source, target, actions, event, guard, trigger, securityRule, name);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultInternalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultInternalTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,5 +52,21 @@ public class DefaultInternalTransition<S, E> extends AbstractInternalTransition<
 	public DefaultInternalTransition(State<S, E> source, Collection<Action<S, E>> actions, E event, Guard<S, E> guard,
 			Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, actions, event, guard, trigger, securityRule);
+	}
+	
+	/**
+	 * Instantiates a new default internal transition.
+	 *
+	 * @param source the source
+	 * @param actions the actions
+	 * @param event the event
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 * @param securityRule the security rule
+	 * @param name the name
+	 */
+	public DefaultInternalTransition(State<S, E> source, Collection<Action<S, E>> actions, E event, Guard<S, E> guard,
+			Trigger<S, E> trigger, SecurityRule securityRule, String name) {
+		super(source, actions, event, guard, trigger, securityRule, name);
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultLocalTransition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/DefaultLocalTransition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,23 @@ public class DefaultLocalTransition<S, E> extends AbstractLocalTransition<S, E> 
 	public DefaultLocalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event,
 			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule) {
 		super(source, target, actions, event, guard, trigger, securityRule);
+	}
+
+	/**
+	 * Instantiates a new default local transition.
+	 *
+	 * @param source the source
+	 * @param target the target
+	 * @param actions the actions
+	 * @param event the event
+	 * @param guard the guard
+	 * @param trigger the trigger
+	 * @param securityRule the security rule
+	 * @param name the name
+	 */
+	public DefaultLocalTransition(State<S, E> source, State<S, E> target, Collection<Action<S, E>> actions, E event,
+			Guard<S, E> guard, Trigger<S, E> trigger, SecurityRule securityRule, String name) {
+		super(source, target, actions, event, guard, trigger, securityRule, name);
 	}
 
 	@Override

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/transition/Transition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,6 +99,13 @@ public interface Transition<S, E> {
 	 * @return the security rule
 	 */
 	SecurityRule getSecurityRule();
+	
+	/**
+	 * Gets the name.
+	 * 
+	 * @return the name
+	 */
+	String getName();
 
 	/**
 	 * Adds the action listener.

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/config/model/StateMachineModelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class StateMachineModelTests {
 
 
 		Collection<TransitionData<String, String>> transitions = new ArrayList<>();
-		TransitionData<String, String> transitionData1 = new TransitionData<String, String>("S1", "S2", null, "E1", null, null, null, null, TransitionKind.EXTERNAL, null);
+		TransitionData<String, String> transitionData1 = new TransitionData<String, String>("S1", "S2", null, "E1", null, null, null, null, TransitionKind.EXTERNAL, null, "");
 		transitions.add(transitionData1);
 		Map<String, List<ChoiceData<String, String>>> choices = new HashMap<>();
 		Map<String, List<JunctionData<String, String>>> junctions = new HashMap<>();

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/support/StateContextExpressionMethodsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,6 +150,11 @@ public class StateContextExpressionMethodsTests {
 
 		@Override
 		public void removeActionListener(ActionListener<SpelStates, SpelEvents> listener) {
+		}
+
+		@Override
+		public String getName() {
+			return "";
 		}
 	}
 

--- a/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
+++ b/spring-statemachine-uml/src/main/java/org/springframework/statemachine/uml/support/UmlModelParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -425,12 +425,12 @@ public class UmlModelParser {
 							if (cprentries != null && cprentries.size() == 1) {
 								addTransitionData(new TransitionData<String, String>(resolveName(transition.getSource()),
 										cprentries.get(0).getName(), signal.getName(), UmlUtils.resolveTransitionActions(transition, resolver),
-										guard, UmlUtils.mapUmlTransitionType(transition)));
+										guard, UmlUtils.mapUmlTransitionType(transition), transition.getName()));
 							}
 						} else {
 							addTransitionData(new TransitionData<String, String>(resolveName(transition.getSource()),
 									resolveName(transition.getTarget()), signal.getName(), UmlUtils.resolveTransitionActions(transition, resolver),
-									guard, UmlUtils.mapUmlTransitionType(transition)));
+									guard, UmlUtils.mapUmlTransitionType(transition), transition.getName()));
 						}
 					}
 				} else if (event instanceof TimeEvent) {
@@ -443,7 +443,7 @@ public class UmlModelParser {
 						}
 						addTransitionData(new TransitionData<String, String>(resolveName(transition.getSource()),
 								resolveName(transition.getTarget()), period, count, UmlUtils.resolveTransitionActions(transition, resolver),
-								guard, UmlUtils.mapUmlTransitionType(transition)));
+								guard, UmlUtils.mapUmlTransitionType(transition), transition.getName()));
 					}
 				}
 			}
@@ -452,7 +452,7 @@ public class UmlModelParser {
 			if (shouldCreateAnonymousTransition(transition)) {
 				addTransitionData(new TransitionData<String, String>(resolveName(transition.getSource()), resolveName(transition.getTarget()),
 						null, UmlUtils.resolveTransitionActions(transition, resolver), resolveGuard(transition),
-						UmlUtils.mapUmlTransitionType(transition)));
+						UmlUtils.mapUmlTransitionType(transition), transition.getName()));
 			}
 		}
 	}


### PR DESCRIPTION
# Use case

Given two instances of a `StateMachine<S, E>` resulting from the same `StateMachineFactory<S, E>` and a `StateMachineListener<S, E>`, I can listen for state changes and uniquely identify the state by its id, regardless of the state machine instance:

    @Override
    stateEntered(State<S, E> state) {
        S id = state.getId();
        // "state" is a different object depending on the state machine instance
        // "id" is the same in different state machine instances
    }

For transitions, this is not possible:

    @Override
    public void transition(Transition<S, E> transition) {
        // "transition" is a different object depending on the state machine instance
        // there is no "id" available
    }

In the current implementation I did not find a way to uniquely identify the `Transition` across `StateMachine` instances. In UML, transitions can be identified by name. Consequently, I implemented named transitions as a solution for above use case.

# JIRA

There is no related issue in JIRA (as to my knowledge).

# CLA

Yes, I have signed the CLA.