### PR TITLE
flag to execute actions in sync way while accepting event

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/ObjectStateMachineFactory.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/ObjectStateMachineFactory.java
@@ -79,7 +79,7 @@ public class ObjectStateMachineFactory<S, E> extends AbstractStateMachineFactory
 				extendedState, uuid);
 		machine.setId(machineId);
 		machine.setHistoryState(historyState);
-		machine.setTransitionConflightPolicy(stateMachineModel.getConfigurationData().getTransitionConflictPolicy());
+		machine.setTransitionConflictPolicy(stateMachineModel.getConfigurationData().getTransitionConflictPolicy());
 		if (contextEventsEnabled != null) {
 			machine.setContextEventsEnabled(contextEventsEnabled);
 		}

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/builders/StateMachineConfigurationBuilder.java
@@ -79,6 +79,7 @@ public class StateMachineConfigurationBuilder<S, E>
 	private StateMachineMonitor<S, E> stateMachineMonitor;
 	private final List<StateMachineInterceptor<S, E>> interceptors = new ArrayList<StateMachineInterceptor<S, E>>();
 	private StateMachineRuntimePersister<S, E, ?> persister;
+	private boolean executeActionsInSyncEnabled;
 
 	/**
 	 * Instantiates a new state machine configuration builder.
@@ -149,7 +150,9 @@ public class StateMachineConfigurationBuilder<S, E>
 		return new ConfigurationData<S, E>(beanFactory, autoStart, ensemble, listeners, securityEnabled,
 				transitionSecurityAccessDecisionManager, eventSecurityAccessDecisionManager, eventSecurityRule,
 				transitionSecurityRule, verifierEnabled, verifier, machineId, stateMachineMonitor, interceptorsCopy,
-				transitionConflictPolicy, stateDoActionPolicy, stateDoActionPolicyTimeout, regionExecutionPolicy);
+				transitionConflictPolicy, stateDoActionPolicy, stateDoActionPolicyTimeout, regionExecutionPolicy,
+				executeActionsInSyncEnabled);
+
 	}
 
 	/**
@@ -306,5 +309,13 @@ public class StateMachineConfigurationBuilder<S, E>
 	 */
 	public void setRegionExecutionPolicy(RegionExecutionPolicy regionExecutionPolicy) {
 		this.regionExecutionPolicy = regionExecutionPolicy;
+	}
+
+	/**
+	 * sets execute actions in sync flag
+	 * @param executeActionsInSyncEnabled
+	 */
+	public void setExecuteActionsInSyncEnabled(boolean executeActionsInSyncEnabled) {
+		this.executeActionsInSyncEnabled = executeActionsInSyncEnabled;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ConfigurationConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/ConfigurationConfigurer.java
@@ -105,4 +105,15 @@ public interface ConfigurationConfigurer<S, E> extends
 	 * @return the configuration configurer
 	 */
 	ConfigurationConfigurer<S, E> regionExecutionPolicy(RegionExecutionPolicy regionExecutionPolicy);
+
+
+	/**
+	 * Specify if state machine should execute all transition actions, and state entry, exit actions
+	 * in sync while accepting event.
+	 * any action execution failure can prevent acceptance of the event
+	 *
+	 * @param executeActionsInSyncEnabled the autoStartup flag
+	 * @return configurer for chaining
+	 */
+	ConfigurationConfigurer<S, E> executeActionsInSyncEnabled(boolean executeActionsInSyncEnabled);
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultConfigurationConfigurer.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configurers/DefaultConfigurationConfigurer.java
@@ -49,6 +49,7 @@ public class DefaultConfigurationConfigurer<S, E>
 	private Long stateDoActionPolicyTimeout;
 	private RegionExecutionPolicy regionExecutionPolicy;
 	private final List<StateMachineListener<S, E>> listeners = new ArrayList<StateMachineListener<S, E>>();
+	private boolean executeActionsInSyncEnabled = false;
 
 	@Override
 	public void configure(StateMachineConfigurationBuilder<S, E> builder) throws Exception {
@@ -59,6 +60,7 @@ public class DefaultConfigurationConfigurer<S, E>
 		builder.setTransitionConflictPolicy(transitionConflightPolicy);
 		builder.setStateDoActionPolicy(stateDoActionPolicy, stateDoActionPolicyTimeout);
 		builder.setRegionExecutionPolicy(regionExecutionPolicy);
+		builder.setExecuteActionsInSyncEnabled(executeActionsInSyncEnabled);
 	}
 
 	@Override
@@ -106,6 +108,13 @@ public class DefaultConfigurationConfigurer<S, E>
 	@Override
 	public ConfigurationConfigurer<S, E> regionExecutionPolicy(RegionExecutionPolicy regionExecutionPolicy) {
 		this.regionExecutionPolicy = regionExecutionPolicy;
+		return this;
+	}
+
+
+	@Override
+	public ConfigurationConfigurer<S, E> executeActionsInSyncEnabled(boolean executeActionsInSync) {
+		this.executeActionsInSyncEnabled = executeActionsInSync;
 		return this;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ConfigurationData.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/model/ConfigurationData.java
@@ -60,6 +60,7 @@ public class ConfigurationData<S, E> {
 	private final StateMachineMonitor<S, E> stateMachineMonitor;
 	private final List<StateMachineInterceptor<S, E>> interceptors;
 	private final RegionExecutionPolicy regionExecutionPolicy;
+	private final boolean executeActionsInSyncEnabled;
 
 	/**
 	 * Instantiates a new state machine configuration config data.
@@ -96,7 +97,7 @@ public class ConfigurationData<S, E> {
 			List<StateMachineInterceptor<S, E>> interceptors) {
 		this(beanFactory, autoStart, ensemble, listeners, securityEnabled, transitionSecurityAccessDecisionManager,
 				eventSecurityAccessDecisionManager, eventSecurityRule, transitionSecurityRule, verifierEnabled,
-				verifier, machineId, stateMachineMonitor, interceptors, null, null, null, null);
+				verifier, machineId, stateMachineMonitor, interceptors, null, null, null, null, false);
 	}
 
 	/**
@@ -120,6 +121,7 @@ public class ConfigurationData<S, E> {
 	 * @param stateDoActionPolicy the state do action policy
 	 * @param stateDoActionPolicyTimeout the state do action policy timeout
 	 * @param regionExecutionPolicy the region execution policy
+	 * @param executeActionsInSyncEnabled the execute actions in sync enabled flag
 	 */
 	public ConfigurationData(BeanFactory beanFactory, boolean autoStart, StateMachineEnsemble<S, E> ensemble,
 			List<StateMachineListener<S, E>> listeners, boolean securityEnabled,
@@ -129,7 +131,7 @@ public class ConfigurationData<S, E> {
 			String machineId, StateMachineMonitor<S, E> stateMachineMonitor,
 			List<StateMachineInterceptor<S, E>> interceptors, TransitionConflictPolicy transitionConflightPolicy,
 			StateDoActionPolicy stateDoActionPolicy, Long stateDoActionPolicyTimeout,
-			RegionExecutionPolicy regionExecutionPolicy) {
+			RegionExecutionPolicy regionExecutionPolicy,boolean executeActionsInSyncEnabled) {
 		this.beanFactory = beanFactory;
 		this.autoStart = autoStart;
 		this.ensemble = ensemble;
@@ -148,6 +150,7 @@ public class ConfigurationData<S, E> {
 		this.stateDoActionPolicy = stateDoActionPolicy;
 		this.stateDoActionPolicyTimeout = stateDoActionPolicyTimeout;
 		this.regionExecutionPolicy = regionExecutionPolicy;
+		this.executeActionsInSyncEnabled = executeActionsInSyncEnabled;
 	}
 
 	public String getMachineId() {
@@ -305,5 +308,15 @@ public class ConfigurationData<S, E> {
 	 */
 	public RegionExecutionPolicy getRegionExecutionPolicy() {
 		return regionExecutionPolicy;
+	}
+
+
+	/**
+	 * Checks if execute actions in sync is enabled.
+	 *
+	 * @return true, if execute actions in sync is enabled
+	 */
+	public boolean isExecuteActionsInSyncEnabled() {
+		return executeActionsInSyncEnabled;
 	}
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -128,6 +128,8 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 
 	private StateMachine<S, E> parentMachine;
 
+	private boolean executeActionsInSyncEnabled;
+
 	/**
 	 * Instantiates a new abstract state machine.
 	 *
@@ -310,7 +312,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		}
 
 		ReactiveStateMachineExecutor<S, E> executor = new ReactiveStateMachineExecutor<S, E>(this, getRelayStateMachine(), transitions,
-				triggerToTransitionMap, triggerlessTransitions, initialTransition, initialEvent, transitionConflictPolicy);
+				triggerToTransitionMap, triggerlessTransitions, initialTransition, initialEvent, transitionConflictPolicy, executeActionsInSyncEnabled);
 		if (getBeanFactory() != null) {
 			executor.setBeanFactory(getBeanFactory());
 		}
@@ -614,7 +616,7 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 	 *
 	 * @param transitionConflictPolicy the new transition conflict policy
 	 */
-	public void setTransitionConflightPolicy(TransitionConflictPolicy transitionConflictPolicy) {
+	public void setTransitionConflictPolicy(TransitionConflictPolicy transitionConflictPolicy) {
 		this.transitionConflictPolicy = transitionConflictPolicy;
 	}
 
@@ -1483,5 +1485,15 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 		} else {
 			return false;
 		}
+	}
+
+	/**
+	 * Sets execute actions in sync flag.
+	 * if enabled statemachine will execute all actions reactive non-reactive in sync while accepting an event,
+	 * If any action results in error statemachine will error out
+	 * @param executeActionsInSyncEnabled
+	 */
+	public void setExecuteActionsInSync(boolean executeActionsInSyncEnabled) {
+		this.executeActionsInSyncEnabled = executeActionsInSyncEnabled;
 	}
 }


### PR DESCRIPTION
Added a flag in statemachine to run all transition and state entry/exit actions in sync while accepting an event.
This will allow the caller of `sendEvent` to know if there was any action failure and  counter measures can be taken to handle failed execution.

This feature is very useful if we use a spring state machine for an Order use-case where **Actions** can update to database independently.
Using this flag enables us to make the whole part sending event and execution of actions part of a single transaction.