### PR TITLE
1060 Update kryo library to 5.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		log4jVersion = '1.2.17'
 		springBootVersion = '2.7.0'
 		eclipsePersistenceVersion = '2.1.1'
-		kryoVersion = '4.0.2'
+		kryoVersion = '5.3.0'
 		springCloudClusterVersion = '1.0.2.RELEASE'
 		springShellVersion = '1.1.0.RELEASE'
 		eclipseEmfXmiVersion = '2.11.1-v20150805-0538'
@@ -95,7 +95,7 @@ configure(allprojects) {
 		dependencies {
 			dependency "log4j:log4j:$log4jVersion"
 			dependency "org.eclipse.persistence:javax.persistence:$eclipsePersistenceVersion"
-			dependency "com.esotericsoftware:kryo-shaded:$kryoVersion"
+			dependency "com.esotericsoftware.kryo:kryo5:$kryoVersion"
 			dependency "org.springframework.shell:spring-shell:$springShellVersion"
 			dependency "org.eclipse.uml2:uml:$eclipseUml2UmlVersion"
 			dependency "org.eclipse.uml2:types:$eclipseUml2TypesVersion"
@@ -297,7 +297,7 @@ project('spring-statemachine-kryo') {
 
 	dependencies {
 		compile project(':spring-statemachine-core')
-		compile 'com.esotericsoftware:kryo-shaded'
+		compile 'com.esotericsoftware.kryo:kryo5'
 
 		testCompile (project(':spring-statemachine-test')) { dep ->
 			exclude group: 'junit', module: 'junit'

--- a/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisStateMachineContextRepository.java
+++ b/spring-statemachine-data/redis/src/main/java/org/springframework/statemachine/data/redis/RedisStateMachineContextRepository.java
@@ -18,7 +18,9 @@ package org.springframework.statemachine.data.redis;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.UUID;
-
+import org.springframework.statemachine.kryo.StateMachineContextSerializer;
+import org.springframework.statemachine.kryo.MessageHeadersSerializer;
+import org.springframework.statemachine.kryo.UUIDSerializer;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,13 +28,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.StateMachineContextRepository;
-import org.springframework.statemachine.kryo.MessageHeadersSerializer;
-import org.springframework.statemachine.kryo.StateMachineContextSerializer;
-import org.springframework.statemachine.kryo.UUIDSerializer;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /**
  * A {@link StateMachineContextRepository} backed by a redis and kryo serialization.

--- a/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/AbstractKryoStateMachineSerialisationService.java
+++ b/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/AbstractKryoStateMachineSerialisationService.java
@@ -1,3 +1,4 @@
+package org.springframework.statemachine.kryo;
 /*
  * Copyright 2017-2018 the original author or authors.
  *
@@ -13,24 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.kryo;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
+import com.esotericsoftware.kryo.kryo5.util.Pool;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.service.StateMachineSerialisationService;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-import com.esotericsoftware.kryo.pool.KryoCallback;
-import com.esotericsoftware.kryo.pool.KryoFactory;
-import com.esotericsoftware.kryo.pool.KryoPool;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Abstract base implementation for {@link StateMachineSerialisationService} using kryo.
@@ -42,115 +39,102 @@ import com.esotericsoftware.kryo.pool.KryoPool;
  */
 public abstract class AbstractKryoStateMachineSerialisationService<S, E> implements StateMachineSerialisationService<S, E> {
 
-	protected final KryoPool pool;
+    protected final Pool<Kryo> pool;
 
-	protected AbstractKryoStateMachineSerialisationService() {
-		KryoFactory factory = new KryoFactory() {
+    protected AbstractKryoStateMachineSerialisationService() {
+        this.pool= new Pool<Kryo>(true,false,10) {
+            @Override
+            protected Kryo create() {
+                Kryo kryo=new Kryo();
+                kryo.setClassLoader(ClassUtils.getDefaultClassLoader());
+                configureKryoInstance(kryo);
+                return kryo;
+            }
+        };
+    }
 
-			@Override
-			public Kryo create() {
-				Kryo kryo = new Kryo();
-				// kryo is really getting trouble checking things if class loaders
-				// doesn't match. for now just use below trick before we try
-				// to go fully on beans and get a bean class loader.
-				kryo.setClassLoader(ClassUtils.getDefaultClassLoader());
-				configureKryoInstance(kryo);
-				return kryo;
-			}
-		};
-		this.pool = new KryoPool.Builder(factory).softReferences().build();
-	}
+    @Override
+    public byte[] serialiseStateMachineContext(StateMachineContext<S, E> context) throws Exception {
+        return encode(context);
+    }
 
-	@Override
-	public byte[] serialiseStateMachineContext(StateMachineContext<S, E> context) throws Exception {
-		return encode(context);
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public StateMachineContext<S, E> deserialiseStateMachineContext(byte[] data) throws Exception {
+        return decode(data, StateMachineContext.class);
+    }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public StateMachineContext<S, E> deserialiseStateMachineContext(byte[] data) throws Exception {
-		return decode(data, StateMachineContext.class);
-	}
+    /**
+     * Subclasses implement this method to encode with Kryo.
+     *
+     * @param kryo the Kryo instance
+     * @param object the object to encode
+     * @param output the Kryo Output instance
+     */
+    protected abstract void doEncode(Kryo kryo, Object object, Output output);
 
-	/**
-	 * Subclasses implement this method to encode with Kryo.
-	 *
-	 * @param kryo the Kryo instance
-	 * @param object the object to encode
-	 * @param output the Kryo Output instance
-	 */
-	protected abstract void doEncode(Kryo kryo, Object object, Output output);
+    /**
+     * Subclasses implement this method to decode with Kryo.
+     *
+     * @param kryo the Kryo instance
+     * @param input the Kryo Input instance
+     * @param type the class of the decoded object
+     * @param <T> the type for decoded object
+     * @return the decoded object
+     */
+    protected abstract <T> T doDecode(Kryo kryo, Input input, Class<T> type);
 
-	/**
-	 * Subclasses implement this method to decode with Kryo.
-	 *
-	 * @param kryo the Kryo instance
-	 * @param input the Kryo Input instance
-	 * @param type the class of the decoded object
-	 * @param <T> the type for decoded object
-	 * @return the decoded object
-	 */
-	protected abstract <T> T doDecode(Kryo kryo, Input input, Class<T> type);
+    /**
+     * Subclasses implement this to configure the kryo instance.
+     * This is invoked on each new Kryo instance when it is created.
+     *
+     * @param kryo the kryo instance
+     */
+    protected abstract void configureKryoInstance(Kryo kryo);
 
-	/**
-	 * Subclasses implement this to configure the kryo instance.
-	 * This is invoked on each new Kryo instance when it is created.
-	 *
-	 * @param kryo the kryo instance
-	 */
-	protected abstract void configureKryoInstance(Kryo kryo);
+    private byte[] encode(Object object) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        encode(object, bos);
+        byte[] bytes = bos.toByteArray();
+        bos.close();
+        return bytes;
+    }
 
-	private byte[] encode(Object object) throws IOException {
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		encode(object, bos);
-		byte[] bytes = bos.toByteArray();
-		bos.close();
-		return bytes;
-	}
+    private void encode(final Object object, OutputStream outputStream) throws IOException {
+        Assert.notNull(object, "cannot encode a null object");
+        Assert.notNull(outputStream, "'outputSteam' cannot be null");
+        final Output output = (outputStream instanceof Output ? (Output) outputStream : new Output(outputStream));
+        Kryo kryo=this.pool.obtain();
+        try{
+            doEncode(kryo,object,output);
+        }finally {
+            pool.free(kryo);
+            output.close();
+        }
+    }
 
-	private void encode(final Object object, OutputStream outputStream) throws IOException {
-		Assert.notNull(object, "cannot encode a null object");
-		Assert.notNull(outputStream, "'outputSteam' cannot be null");
-		final Output output = (outputStream instanceof Output ? (Output) outputStream : new Output(outputStream));
-		this.pool.run(new KryoCallback<Void>() {
+    private <T> T decode(byte[] bytes, Class<T> type) throws IOException {
+        Assert.notNull(bytes, "'bytes' cannot be null");
+        final Input input = new Input(bytes);
+        try {
+            return decode(input, type);
+        }
+        finally {
+            input.close();
+        }
+    }
 
-			@Override
-			public Void execute(Kryo kryo) {
-				doEncode(kryo, object, output);
-				return null;
-			}
-		});
-		output.close();
-	}
-
-	private <T> T decode(byte[] bytes, Class<T> type) throws IOException {
-		Assert.notNull(bytes, "'bytes' cannot be null");
-		final Input input = new Input(bytes);
-		try {
-			return decode(input, type);
-		}
-		finally {
-			input.close();
-		}
-	}
-
-	private <T> T decode(InputStream inputStream, final Class<T> type) throws IOException {
-		Assert.notNull(inputStream, "'inputStream' cannot be null");
-		Assert.notNull(type, "'type' cannot be null");
-		final Input input = (inputStream instanceof Input ? (Input) inputStream : new Input(inputStream));
-		T result = null;
-		try {
-			result = this.pool.run(new KryoCallback<T>(){
-
-				@Override
-				public T execute(Kryo kryo) {
-					return doDecode(kryo, input, type);
-				}
-			});
-		}
-		finally {
-			input.close();
-		}
-		return result;
-	}
+    private <T> T decode(InputStream inputStream, final Class<T> type) throws IOException {
+        Assert.notNull(inputStream, "'inputStream' cannot be null");
+        Assert.notNull(type, "'type' cannot be null");
+        final Input input = (inputStream instanceof Input ? (Input) inputStream : new Input(inputStream));
+        T result = null;
+        Kryo kryo=this.pool.obtain();
+        try{
+            return doDecode(kryo,input,type);
+        }finally {
+            pool.free(kryo);
+            input.close();
+        }
+    }
 }

--- a/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/KryoStateMachineSerialisationService.java
+++ b/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/KryoStateMachineSerialisationService.java
@@ -1,3 +1,4 @@
+package org.springframework.statemachine.kryo;
 /*
  * Copyright 2017 the original author or authors.
  *
@@ -13,17 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.kryo;
 
-import java.util.UUID;
-
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.service.StateMachineSerialisationService;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import java.util.UUID;
 
 /**
  * Implementation for {@link StateMachineSerialisationService} using kryo.
@@ -35,20 +34,21 @@ import com.esotericsoftware.kryo.io.Output;
  */
 public class KryoStateMachineSerialisationService<S, E> extends AbstractKryoStateMachineSerialisationService<S, E> {
 
-	@Override
-	protected void doEncode(Kryo kryo, Object object, Output output) {
-		kryo.writeObject(output, object);
-	}
+    @Override
+    protected void doEncode(Kryo kryo, Object object, Output output) {
+        kryo.writeObject(output, object);
+    }
 
-	@Override
-	protected <T> T doDecode(Kryo kryo, Input input, Class<T> type) {
-		return kryo.readObject(input, type);
-	}
+    @Override
+    protected <T> T doDecode(Kryo kryo, Input input, Class<T> type) {
+        return kryo.readObject(input, type);
+    }
 
-	@Override
-	protected void configureKryoInstance(Kryo kryo) {
-		kryo.addDefaultSerializer(StateMachineContext.class, new StateMachineContextSerializer<S, E>());
-		kryo.addDefaultSerializer(MessageHeaders.class, new MessageHeadersSerializer());
-		kryo.addDefaultSerializer(UUID.class, new UUIDSerializer());
-	}
+    @Override
+    protected void configureKryoInstance(Kryo kryo) {
+        kryo.setRegistrationRequired(false);
+        kryo.addDefaultSerializer(StateMachineContext.class, new StateMachineContextSerializer<S, E>());
+        kryo.addDefaultSerializer(MessageHeaders.class, new MessageHeadersSerializer());
+        kryo.addDefaultSerializer(UUID.class, new UUIDSerializer());
+    }
 }

--- a/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/MessageHeadersSerializer.java
+++ b/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/MessageHeadersSerializer.java
@@ -1,3 +1,4 @@
+package org.springframework.statemachine.kryo;
 /*
  * Copyright 2015 the original author or authors.
  *
@@ -13,18 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.kryo;
+
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
+import org.springframework.messaging.MessageHeaders;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import org.springframework.messaging.MessageHeaders;
-
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 
 /**
  * Kryo {@link Serializer} for spring messaging message headers.
@@ -34,20 +33,20 @@ import com.esotericsoftware.kryo.io.Output;
  */
 public class MessageHeadersSerializer extends Serializer<MessageHeaders> {
 
-	@Override
-	public void write(Kryo kryo, Output output, MessageHeaders object) {
-		HashMap<String, Object> map = new HashMap<String, Object>();
-		for (Entry<String, Object> entry : object.entrySet()) {
-			map.put(entry.getKey(), entry.getValue());
-		}
-		kryo.writeClassAndObject(output, map);
-	}
+    @Override
+    public void write(Kryo kryo, Output output, MessageHeaders object) {
+        HashMap<String, Object> map = new HashMap<String, Object>();
+        for (Entry<String, Object> entry : object.entrySet()) {
+            map.put(entry.getKey(), entry.getValue());
+        }
+        kryo.writeClassAndObject(output, map);
+    }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public MessageHeaders read(Kryo kryo, Input input, Class<MessageHeaders> type) {
-		Map<String, Object> eventHeaders = (Map<String, Object>) kryo.readClassAndObject(input);
-		return new MessageHeaders(eventHeaders);
-	}
+    @SuppressWarnings("unchecked")
+    @Override
+    public MessageHeaders read(Kryo kryo, Input input, Class<? extends MessageHeaders> aClass) {
+        Map<String, Object> eventHeaders = (Map<String, Object>) kryo.readClassAndObject(input);
+        return new MessageHeaders(eventHeaders);
+    }
 
 }

--- a/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/StateMachineContextSerializer.java
+++ b/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/StateMachineContextSerializer.java
@@ -1,3 +1,4 @@
+package org.springframework.statemachine.kryo;
 /*
  * Copyright 2015-2019 the original author or authors.
  *
@@ -13,20 +14,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.kryo;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.support.DefaultExtendedState;
 import org.springframework.statemachine.support.DefaultStateMachineContext;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Kryo {@link Serializer} for {@link StateMachineContext}.
@@ -38,41 +37,41 @@ import com.esotericsoftware.kryo.io.Output;
  */
 public class StateMachineContextSerializer<S, E> extends Serializer<StateMachineContext<S, E>> {
 
-	// NOTE: when structure of this serialisation is changed, see how things are tested
-	//       in StateMachineContextSerializerTests.
+    // NOTE: when structure of this serialisation is changed, see how things are tested
+    //       in StateMachineContextSerializerTests.
 
-	@Override
-	public void write(Kryo kryo, Output output, StateMachineContext<S, E> context) {
-		kryo.writeClassAndObject(output, context.getEvent());
-		kryo.writeClassAndObject(output, context.getState());
-		kryo.writeClassAndObject(output, context.getEventHeaders());
-		kryo.writeClassAndObject(output, context.getExtendedState() != null ? context.getExtendedState().getVariables() : null);
-		kryo.writeClassAndObject(output, context.getChilds());
-		kryo.writeClassAndObject(output, context.getHistoryStates());
-		kryo.writeClassAndObject(output, context.getId());
-		// child refs were added after initial implementation, leaving this here
-		// in case it's starting to cause issues with any existing serialised contexts
-		// which doesn't have this field
-		// NOTE: PR #722 added fixes with new tests
-		kryo.writeClassAndObject(output, context.getChildReferences());
-	}
+    @Override
+    public void write(Kryo kryo, Output output, StateMachineContext<S, E> context) {
+        kryo.writeClassAndObject(output, context.getEvent());
+        kryo.writeClassAndObject(output, context.getState());
+        kryo.writeClassAndObject(output, context.getEventHeaders());
+        kryo.writeClassAndObject(output, context.getExtendedState() != null ? context.getExtendedState().getVariables() : null);
+        kryo.writeClassAndObject(output, context.getChilds());
+        kryo.writeClassAndObject(output, context.getHistoryStates());
+        kryo.writeClassAndObject(output, context.getId());
+        // child refs were added after initial implementation, leaving this here
+        // in case it's starting to cause issues with any existing serialised contexts
+        // which doesn't have this field
+        // NOTE: PR #722 added fixes with new tests
+        kryo.writeClassAndObject(output, context.getChildReferences());
+    }
 
-	@SuppressWarnings("unchecked")
-	@Override
-	public StateMachineContext<S, E> read(Kryo kryo, Input input, Class<StateMachineContext<S, E>> clazz) {
-		E event = (E) kryo.readClassAndObject(input);
-		S state = (S) kryo.readClassAndObject(input);
-		Map<String, Object> eventHeaders = (Map<String, Object>) kryo.readClassAndObject(input);
-		Map<Object, Object> variables = (Map<Object, Object>) kryo.readClassAndObject(input);
-		List<StateMachineContext<S, E>> childs = (List<StateMachineContext<S, E>>) kryo.readClassAndObject(input);
-		Map<S, S> historyStates = (Map<S, S>) kryo.readClassAndObject(input);
-		String id = (String) kryo.readClassAndObject(input);
-		List<String> childRefs = new ArrayList<>();
-		if(input.canReadInt()) {
-			childRefs = (List<String>) kryo.readClassAndObject(input);
-		}
+    @SuppressWarnings("unchecked")
+    @Override
+    public StateMachineContext<S, E> read(Kryo kryo, Input input, Class<? extends StateMachineContext<S, E>> clazz) {
+        E event = (E) kryo.readClassAndObject(input);
+        S state = (S) kryo.readClassAndObject(input);
+        Map<String, Object> eventHeaders = (Map<String, Object>) kryo.readClassAndObject(input);
+        Map<Object, Object> variables = (Map<Object, Object>) kryo.readClassAndObject(input);
+        List<StateMachineContext<S, E>> childs = (List<StateMachineContext<S, E>>) kryo.readClassAndObject(input);
+        Map<S, S> historyStates = (Map<S, S>) kryo.readClassAndObject(input);
+        String id = (String) kryo.readClassAndObject(input);
+        List<String> childRefs = new ArrayList<>();
+        if(input.canReadInt()) {
+            childRefs = (List<String>) kryo.readClassAndObject(input);
+        }
 
-		return new DefaultStateMachineContext<S, E>(childRefs, childs, state, event, eventHeaders,
-				new DefaultExtendedState(variables), historyStates, id);
-	}
+        return new DefaultStateMachineContext<S, E>(childRefs, childs, state, event, eventHeaders,
+                new DefaultExtendedState(variables), historyStates, id);
+    }
 }

--- a/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/UUIDSerializer.java
+++ b/spring-statemachine-kryo/src/main/java/org/springframework/statemachine/kryo/UUIDSerializer.java
@@ -1,3 +1,4 @@
+package org.springframework.statemachine.kryo;
 /*
  * Copyright 2015 the original author or authors.
  *
@@ -13,14 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.statemachine.kryo;
+
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 import java.util.UUID;
-
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
 
 /**
  * Kryo {@link Serializer} for {@link UUID}.
@@ -30,21 +30,23 @@ import com.esotericsoftware.kryo.io.Output;
  */
 public class UUIDSerializer extends Serializer<UUID> {
 
-	/**
-	 * Instantiates a new UUID serializer.
-	 */
-	public UUIDSerializer() {
-		setImmutable(true);
-	}
+    /**
+     * Instantiates a new UUID serializer.
+     */
+    public UUIDSerializer() {
+        setImmutable(true);
+    }
 
-	@Override
-	public void write(final Kryo kryo, final Output output, final UUID uuid) {
-		output.writeLong(uuid.getMostSignificantBits());
-		output.writeLong(uuid.getLeastSignificantBits());
-	}
+    @Override
+    public void write(final Kryo kryo, final Output output, final UUID uuid) {
+        output.writeLong(uuid.getMostSignificantBits());
+        output.writeLong(uuid.getLeastSignificantBits());
+    }
 
-	@Override
-	public UUID read(final Kryo kryo, final Input input, final Class<UUID> uuidClass) {
-		return new UUID(input.readLong(), input.readLong());
-	}
+    @Override
+    public UUID read(final Kryo kryo,final Input input,final Class<? extends UUID> aClass) {
+        return new UUID(input.readLong(), input.readLong());
+    }
+
 }
+

--- a/spring-statemachine-kryo/src/test/java/org/springframework/statemachine/kryo/StateMachineContextSerializerTests.java
+++ b/spring-statemachine-kryo/src/test/java/org/springframework/statemachine/kryo/StateMachineContextSerializerTests.java
@@ -29,10 +29,10 @@ import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.support.DefaultExtendedState;
 import org.springframework.statemachine.support.DefaultStateMachineContext;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.Serializer;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /**
  * Tests for {@link StateMachineContextSerializer}.
@@ -51,7 +51,7 @@ public class StateMachineContextSerializerTests {
 		Kryo kryo = new Kryo();
 		StateMachineContextSerializer<String, String> serializer = new StateMachineContextSerializer<>();
 		kryo.addDefaultSerializer(StateMachineContext.class, serializer);
-
+		kryo.setRegistrationRequired(false);
 		StateMachineContext<String, String> child = new DefaultStateMachineContext<String, String>(new ArrayList<>(), "child", "event1",
 				new HashMap<String, Object>(), new DefaultExtendedState());
 		List<StateMachineContext<String, String>> childs = new ArrayList<>();
@@ -76,7 +76,8 @@ public class StateMachineContextSerializerTests {
 		// and current(V2). raw bytes from V1 to V2.
 		Kryo kryoFrom = new Kryo();
 		Kryo kryoTo = new Kryo();
-
+		kryoFrom.setRegistrationRequired(false);
+		kryoTo.setRegistrationRequired(false);
 		StateMachineContextSerializerV1<String, String> serializerV1 = new StateMachineContextSerializerV1<>();
 		kryoFrom.addDefaultSerializer(StateMachineContext.class, serializerV1);
 
@@ -119,7 +120,7 @@ public class StateMachineContextSerializerTests {
 
 		@SuppressWarnings("unchecked")
 		@Override
-		public StateMachineContext<S, E> read(Kryo kryo, Input input, Class<StateMachineContext<S, E>> clazz) {
+		public StateMachineContext<S, E> read(Kryo kryo, Input input, Class<? extends StateMachineContext<S, E>> clazz) {
 			E event = (E) kryo.readClassAndObject(input);
 			S state = (S) kryo.readClassAndObject(input);
 			Map<String, Object> eventHeaders = (Map<String, Object>) kryo.readClassAndObject(input);

--- a/spring-statemachine-zookeeper/src/main/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachinePersist.java
+++ b/spring-statemachine-zookeeper/src/main/java/org/springframework/statemachine/zookeeper/ZookeeperStateMachinePersist.java
@@ -29,14 +29,13 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.statemachine.StateMachineContext;
 import org.springframework.statemachine.StateMachineException;
 import org.springframework.statemachine.StateMachinePersist;
-import org.springframework.statemachine.kryo.MessageHeadersSerializer;
-import org.springframework.statemachine.kryo.StateMachineContextSerializer;
-import org.springframework.statemachine.kryo.UUIDSerializer;
 import org.springframework.util.Assert;
-
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
+import org.springframework.statemachine.kryo.StateMachineContextSerializer;
+import org.springframework.statemachine.kryo.MessageHeadersSerializer;
+import org.springframework.statemachine.kryo.UUIDSerializer;
+import com.esotericsoftware.kryo.kryo5.Kryo;
+import com.esotericsoftware.kryo.kryo5.io.Input;
+import com.esotericsoftware.kryo.kryo5.io.Output;
 
 /**
  * {@link StateMachinePersist} using zookeeper as a storage and
@@ -57,6 +56,7 @@ public class ZookeeperStateMachinePersist<S, E> implements StateMachinePersist<S
 		@Override
 		protected Kryo initialValue() {
 			Kryo kryo = new Kryo();
+			kryo.setRegistrationRequired(false);
 			kryo.addDefaultSerializer(StateMachineContext.class, new StateMachineContextSerializer());
 			kryo.addDefaultSerializer(MessageHeaders.class, new MessageHeadersSerializer());
 			kryo.addDefaultSerializer(UUID.class, new UUIDSerializer());


### PR DESCRIPTION
The project spring-statemachine-kryo is not compatible with JAVA 11. By updating the library the 5.3.0 version the project can be used in Java 11.
All the changes in the clases were only to adapt to the api changes in the 5.3.0 librar