### PR TITLE
Bugfix/task scheduler lifecycle

### DIFF
--- a/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/TimerSmokeTests.java
+++ b/spring-statemachine-build-tests/src/test/java/org/springframework/statemachine/buildtests/TimerSmokeTests.java
@@ -16,7 +16,10 @@
 package org.springframework.statemachine.buildtests;
 
 import org.junit.Test;
+import org.springframework.core.task.SyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.config.StateMachineBuilder;
 import org.springframework.statemachine.test.StateMachineTestPlan;
@@ -25,8 +28,10 @@ import org.springframework.statemachine.test.StateMachineTestPlanBuilder;
 public class TimerSmokeTests {
 
 	private static ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+	private static ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 	{
 		taskExecutor.initialize();
+		taskScheduler.initialize();
 	}
 
 	private StateMachine<String, String> buildMachine() throws Exception {
@@ -35,7 +40,8 @@ public class TimerSmokeTests {
 
 		builder.configureConfiguration()
 			.withConfiguration()
-				.taskExecutor(taskExecutor);
+				.taskExecutor(taskExecutor)
+					.taskScheduler(taskScheduler);
 
 		builder.configureStates()
 			.withStates()

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachineSystemConstants.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/StateMachineSystemConstants.java
@@ -38,4 +38,7 @@ public abstract class StateMachineSystemConstants {
 	/** Bean name for task executor */
 	public static final String TASK_EXECUTOR_BEAN_NAME = "stateMachineTaskExecutor";
 
+	/** Task scheduler threads prefix **/
+	public static final String TASK_SCHEDULER_THREAD_PREFIX = "spring-state-machine-task-scheduler-";
+
 }

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configuration/StateMachineCommonConfiguration.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configuration/StateMachineCommonConfiguration.java
@@ -20,7 +20,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.statemachine.StateMachineSystemConstants;
 
 /**
@@ -39,7 +39,7 @@ public class StateMachineCommonConfiguration {
 
 	@Bean
 	public TaskScheduler taskScheduler() {
-		return new ConcurrentTaskScheduler();
+		return new ThreadPoolTaskScheduler();
 	}
 
 	@Bean(name = StateMachineHandlerApplicationListener.BEAN_NAME)


### PR DESCRIPTION
`ConcurrentTaskScheduler` doesn't expose any way for it's inner executor to be shutdown, when it's instance is created with the default constructor. This can lead to a scenario where a library user ends up with many unused threads with no clear cues about where they came from. The unmanaged creation of those threads can result in an `OutOfMemoryError` for a client application.

This commit replaces the usage of `ConcurrentTaskScheduler` with `ThreadPoolTaskScheduler`, a type of similar semantics but better API, which includes methods for managing its internal resources lifecycle. Also it implements spring-beans interfaces which makes it more suitable to be managed by a Spring application context.

- Fixes https://github.com/spring-projects/spring-statemachine/issues/624