### PR TITLE
Override Java 1.8 default Map methods in ObservableMap

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ObservableMap.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ObservableMap.java
@@ -19,6 +19,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.springframework.util.Assert;
 
@@ -43,7 +46,7 @@ public class ObservableMap<K, V> implements Map<K, V> {
 	public ObservableMap() {
 		// default constructor needed for kryo, thus
 		// we create delegate here, listener not needed.
-		delegate = new ConcurrentHashMap<K, V>();
+		delegate = new ConcurrentHashMap<>();
 	}
 
 	/**
@@ -130,6 +133,61 @@ public class ObservableMap<K, V> implements Map<K, V> {
 	@Override
 	public Set<java.util.Map.Entry<K, V>> entrySet() {
 		return delegate.entrySet();
+	}
+
+	@Override
+	public V getOrDefault(Object key, V defaultValue) {
+		return delegate.getOrDefault(key, defaultValue);
+	}
+
+	@Override
+	public void forEach(BiConsumer<? super K, ? super V> action) {
+		delegate.forEach(action);
+	}
+
+	@Override
+	public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+		delegate.replaceAll(function);
+	}
+
+	@Override
+	public V putIfAbsent(K key, V value) {
+		return delegate.putIfAbsent(key, value);
+	}
+
+	@Override
+	public boolean remove(Object key, Object value) {
+		return delegate.remove(key, value);
+	}
+
+	@Override
+	public boolean replace(K key, V oldValue, V newValue) {
+		return delegate.replace(key, oldValue, newValue);
+	}
+
+	@Override
+	public V replace(K key, V value) {
+		return delegate.replace(key, value);
+	}
+
+	@Override
+	public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+		return delegate.computeIfAbsent(key, mappingFunction);
+	}
+
+	@Override
+	public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+		return delegate.computeIfPresent(key, remappingFunction);
+	}
+
+	@Override
+	public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+		return delegate.compute(key, remappingFunction);
+	}
+
+	@Override
+	public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+		return delegate.merge(key, value, remappingFunction);
 	}
 
 	@Override


### PR DESCRIPTION
This is to ensure that default map methods will be passed to the delegate, which is in this case an instance of ConcurrentHashMap.

Without this change, an attempt to modify state variables via default methods will be delegated to default Map implementation, which is not thread safe. These methods are already overridden in ConcurrentHashMap.