### PR TITLE
Connect build to ge.spring.io to benefit from deep build insights and faster builds

### DIFF
--- a/.github/workflows/ci-boot.yml
+++ b/.github/workflows/ci-boot.yml
@@ -23,6 +23,10 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Build boot ${{ matrix.boot }} java ${{ matrix.java }}
       run: ./gradlew clean build -PspringBootVersion=${{ matrix.boot }}
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     - name: Tar Build Logs
       if: ${{ failure() }}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,10 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Build with Gradle
       run: ./gradlew clean build
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     - name: Tar Build Logs
       if: ${{ failure() }}
       run: |
@@ -79,7 +83,10 @@ jobs:
     - name: Build and Publish Snapshot
       run: |
         jf gradle clean build -x test artifactoryPublish
-
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     # publish build info so that we can see it in artifactory "builds"
     - name: Publish Build Info
       run: |

--- a/.github/workflows/release-ga.yml
+++ b/.github/workflows/release-ga.yml
@@ -45,6 +45,10 @@ jobs:
       run: |
         jf gradle releaseVersion
         echo PROJECT_VERSION=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}') >> $GITHUB_ENV
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     # build and publish to staging repo.
     # we've allready tested with snapshots so no need to test
     # with a release build as we are not a release train.
@@ -52,6 +56,10 @@ jobs:
       run: |
         jf gradle clean build artifactoryPublish
         jf rt build-publish
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     # we've now done a release build, branch and tag it in github
     - name: Tag Release
       uses: jvalkeal/build-zoo-handler@v0.0.4
@@ -100,6 +108,10 @@ jobs:
     - name: Switch to Next Dev Version
       run: |
         jf gradle nextVersion
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     - uses: jvalkeal/build-zoo-handler@v0.0.4
       with:
         commit-changes-branch: main

--- a/.github/workflows/release-milestone.yml
+++ b/.github/workflows/release-milestone.yml
@@ -49,6 +49,10 @@ jobs:
       run: |
         jf gradle milestoneVersion -PstatemachineMilestone=${{ github.event.inputs.milestone }}
         echo PROJECT_VERSION=$(cat gradle.properties | grep "version=" | awk -F'=' '{print $2}') >> $GITHUB_ENV
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     # build and publish to staging repo.
     # we've allready tested with snapshots so no need to test
     # with a release build as we are not a release train.
@@ -56,6 +60,10 @@ jobs:
       run: |
         jf gradle clean build artifactoryPublish
         jf rt build-publish
+      env:
+        GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
+        GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+        GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
     # we've now done a release build, branch and tag it in github
     - name: Tag Release
       uses: jvalkeal/build-zoo-handler@v0.0.4

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Spring Statemachine
 
-image:https://github.com/spring-projects/spring-statemachine/workflows/CI/badge.svg[link="https://github.com/spring-projects/spring-statemachine/actions"] (GitHub default)
+image:https://github.com/spring-projects/spring-statemachine/workflows/CI/badge.svg[link="https://github.com/spring-projects/spring-statemachine/actions"] (GitHub default) image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?&search.rootProjectNames=spring-statemachine"]
 
 The Spring Statemachine project aims to provide a common infrastructure
 to work with state machine concepts in Spring applications.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,15 @@
+pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		maven { url 'https://repo.spring.io/release' }
+	}
+}
+
+plugins {
+	id 'com.gradle.enterprise' version '3.14.1'
+	id 'io.spring.ge.conventions' version '0.0.14'
+}
+
 rootProject.name = 'spring-statemachine'
 
 include 'spring-statemachine-platform'


### PR DESCRIPTION
This pull request connects the build to the Gradle Enterprise instance at https://ge.spring.io/. This allows the Spring Statemachine project to benefit from deep build insights provided by build scans and faster build speeds for all contributors as a result of remote build caching. 

This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by Spring Statemachine and all other Spring projects. On this Gradle Enterprise instance, Spring Statemachine will have access not only to all of the published build scans, but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

[Spring Boot](https://ge.spring.io/scans?search.rootProjectNames=spring-boot-build), [Spring Framework](https://ge.spring.io/scans?search.rootProjectNames=spring), and [Spring Security](https://ge.spring.io/scans?search.rootProjectNames=spring-security) are already connected to https://ge.spring.io/ and are benefiting from these features. 

For these features to be made possible, appropriate access must be configured to publish build scans and to write to the remote build cache. To ensure a consistent experience for all Spring contributors, the [Spring Gradle Enterprise Conventions](https://github.com/spring-io/gradle-enterprise-conventions) plugin is used. Its documentation details how to configure credentials [to publish build scans](https://github.com/spring-io/gradle-enterprise-conventions#build-scan-publishing-credentials) and [for writing to the remote build cache](https://github.com/spring-io/gradle-enterprise-conventions#credentials).

~~⚠️ For GitHub actions, this will require someone from the Spring team to add the appropriate secrets if they are not already available. Then, a subsequent change will be required to add the credentials to the appropriate workflows. See [the Spring Security Kerberos project](https://github.com/spring-projects/spring-security-kerberos/blame/f738044b15382086d5bea30becdeb60014b75555/.github/workflows/ci.yml#L31-L34) for an example of how these credentials are configured.~~

@trevormarshall was kind enough to configure the necessary credentials. I have gone ahead and updated workflows accordingly. I **have not** updated any workflows that build PRs.

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.