### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release-ga.yml
+++ b/.github/workflows/release-ga.yml
@@ -64,7 +64,7 @@ jobs:
       env:
         PROJECT_VERSION: ${{ env.PROJECT_VERSION }}
       run: |
-        echo "::set-output name=project-version::$PROJECT_VERSION"
+        echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
   # wait manual approval.
   # promote build from staging to releases


### PR DESCRIPTION
## Description

Closes #1112 

Update `.github/workflows/release-ga.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=project-version::$PROJECT_VERSION"
```

**TO-BE**

```yaml
echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
```