### PR TITLE
Upgrade com.gradle.enterprise plugin to 3.16.2

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,7 +3,9 @@ plugins {
 	id "java"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17;
+java {
+	sourceCompatibility = JavaVersion.VERSION_17
+}
 
 repositories {
 	gradlePluginPortal()

--- a/docs/src/reference/asciidoc/getting-started.adoc
+++ b/docs/src/reference/asciidoc/getting-started.adoc
@@ -101,7 +101,10 @@ apply plugin: 'io.spring.dependency-management'
 
 group = 'com.example'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = 1.8
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 repositories {
 	mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ springAsciidoctorBackends=0.0.5
 awaitilityVersion=3.1.6
 reactorBlockHoundVersion=1.0.4.RELEASE
 findbugsVersion=3.0.2
-gradleEnterpriseVersion=3.10.3
-springGeConventionsVersion=0.0.13
+gradleEnterpriseVersion=3.16.2
+springGeConventionsVersion=0.0.15


### PR DESCRIPTION
# Upgrade Enterprise Gradle Plugin

## Bumps
- [com.gradle.enterprise](https://plugins.gradle.org/plugin/com.gradle.enterprise) from 3.14.1 to 3.16.2
- [io.spring.ge.conventions](https://github.com/spring-io/gradle-enterprise-conventions) from 0.0.14 to 0.0.15

## Compatibility
Based on commits in spring-framework repo, internally spring team should support latest Gradle Enterprise plugin:
- Commit with note that only 3.15 version is supported: spring-projects/spring-framework@e3f185a696b0d6ca017a83366f24ed692573d14e 
- Commit with 3.16 version: spring-projects/spring-framework@b7e4fa16cae5f5a45fd661c51d558c8b9e5c39ae