### PR TITLE
Fix infinite loop after resetting state machine

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java
@@ -183,6 +183,9 @@ public abstract class AbstractStateMachine<S, E> extends StateMachineObjectSuppo
 
 	@Override
 	public State<S,E> getState() {
+		if (isRunning()) {
+			return currentState;
+		}
 		// if we're complete assume we're stopped
 		// and state was stashed into lastState
 		State<S, E> s = lastState;

--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveLifecycleManager.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveLifecycleManager.java
@@ -114,7 +114,7 @@ public class ReactiveLifecycleManager implements StateMachineReactiveLifecycle {
 	}
 
 	public boolean isRunning() {
-		return state.get() == LifecycleState.STARTED;
+		return state.get() == LifecycleState.STARTED || state.get() == LifecycleState.STARTING;
 	}
 
 	@Override

--- a/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
+++ b/spring-statemachine-core/src/test/java/org/springframework/statemachine/StateMachineResetTests.java
@@ -343,6 +343,22 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		assertThat(machine.getState().getIds()).containsOnly(SuperState.INITIAL);
 	}
 
+	@Test
+	public void testResetAndStartFromCustomState() {
+		context.register(Config8.class);
+		context.refresh();
+
+		StateMachine<MyState, MyEvent> machine = resolveMachine(context);
+
+		DefaultStateMachineContext<MyState, MyEvent> stateMachineContext = new DefaultStateMachineContext<MyState, MyEvent>(
+				States8.S8_2, null, null, null);
+
+		machine.getStateMachineAccessor().doWithAllRegions(function -> function.resetStateMachineReactively(stateMachineContext).block());
+
+		doStartAndAssert(machine);
+		assertThat(machine.getState().getIds()).containsOnly(States8.S8_5);
+	}
+
 	@Configuration
 	@EnableStateMachine
 	static class Config1 extends EnumStateMachineConfigurerAdapter<States, Events> {
@@ -825,4 +841,43 @@ public class StateMachineResetTests extends AbstractStateMachineTests {
 		}
 
 	}
+
+	@Configuration
+	@EnableStateMachine
+	static class Config8 extends EnumStateMachineConfigurerAdapter<States8, MyEvent> {
+		@Override
+		public void configure(StateMachineStateConfigurer<States8, MyEvent> states)
+				throws Exception {
+			states
+					.withStates()
+					.initial(States8.S8_1)
+					.state(States8.S8_2)
+					.state(States8.S8_3)
+					.state(States8.S8_4)
+					.end(States8.S8_5)
+			;
+		}
+
+		@Override
+		public void configure(final StateMachineTransitionConfigurer<States8, MyEvent> transitions) throws Exception {
+			transitions
+					.withExternal()
+					.source(States8.S8_1).target(States8.S8_2)
+					.and()
+					.withExternal()
+					.source(States8.S8_2).target(States8.S8_3)
+					.and()
+					.withExternal()
+					.source(States8.S8_3).target(States8.S8_4)
+					.and()
+					.withExternal()
+					.source(States8.S8_4).target(States8.S8_5)
+			;
+		}
+	}
+
+	public enum States8 implements MyState {
+		S8_1, S8_2, S8_3, S8_4, S8_5
+	}
+
 }


### PR DESCRIPTION
- Fixes #1011

### Glossary
Description of unit test state names:
`S8_1` - itintial state 
`S8_2` - custom start state that we pass with default context
`S8_5` - end state
`S8_3`, `S8_4` - transit states

### Problem description
In some situations (e.g. app crash) we need to start state machine from custom state in order to resume execution. To do that we are following next steps:

1. Stop state machine with `stopReactively`;
2. Reset via accessor with default context and specified state (`S8_2`);
3. Start machine with `startReactively`;

#### Expected behavior 
Transitions from `S8_2` to `S8_5` with state machine stop

#### Actual behavior 
Infinite loop with transitions `S8_2 -> S8_3 -> S8_4 -> S8_5 -> S8_2 -> S8_3 -> ...` as decribed in #1011

### What causes the problem
1. Resetting state machine leads to `lastState` field being filled with custom value that we passed in context (`S8_2`)
2. After exiting from last state (`S8_5`) `ReactiveStateMachineExecutor` checks triggerless transitions. 

https://github.com/spring-projects/spring-statemachine/blob/4495c7dd7784f35d78c6e88c490466e05bc24cb9/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveStateMachineExecutor.java#L141

3. In normal scenarios this filter must return false and state machine must stop. 

https://github.com/spring-projects/spring-statemachine/blob/4495c7dd7784f35d78c6e88c490466e05bc24cb9/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveStateMachineExecutor.java#L364-L385

4. With not null `lastState` field we'll get its value instead of `currentState` because of `isComplete()` returning `true`.
https://github.com/spring-projects/spring-statemachine/blob/4495c7dd7784f35d78c6e88c490466e05bc24cb9/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/AbstractStateMachine.java#L184-L194

5. Comparing `S8_2` as `source` with `S8_2` as `currentState` returns true, causing this check to be skipped and transition `t` now passing to flatMap. This transition will be called again and again.
https://github.com/spring-projects/spring-statemachine/blob/4495c7dd7784f35d78c6e88c490466e05bc24cb9/spring-statemachine-core/src/main/java/org/springframework/statemachine/support/ReactiveStateMachineExecutor.java#L373-L375

### Fix description
Main goal of this fix is guaranteed returning of `currentState` while state machine is in running life cycle. 
Triggerless state machines do all work inside `STARTING` state during `startReactively` call, so we can count it as a part of running life cycle. 

Existing tests was not affected by this change and passed successfully.

Commenting running check from `getState` will cause added test to run in infinite loop. 