### PR TITLE
Fix StateMachineAnnotationPostProcessor warnning log

### DIFF
--- a/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configuration/StateMachineAnnotationPostProcessorConfiguration.java
+++ b/spring-statemachine-core/src/main/java/org/springframework/statemachine/config/configuration/StateMachineAnnotationPostProcessorConfiguration.java
@@ -33,7 +33,7 @@ public class StateMachineAnnotationPostProcessorConfiguration {
 	private final static String POST_PROCESSOR_BEAN_ID = "org.springframework.statemachine.processor.stateMachineAnnotationPostProcessor";
 
 	@Bean(name = POST_PROCESSOR_BEAN_ID)
-	public StateMachineAnnotationPostProcessor springStateMachineAnnotationPostProcessor() {
+	public static StateMachineAnnotationPostProcessor springStateMachineAnnotationPostProcessor() {
 		return new StateMachineAnnotationPostProcessor();
 	}
 


### PR DESCRIPTION
SpringBoot considers `StateMachineAnnotationPostProcessor` as a `PostProcessor`. The creation of this bean necessitates the prior instantiation of the `StateMachineAnnotationPostProcessorConfiguration` class. However, the instantiation of this class further requires all `PostProcessor`s to process it, including `StateMachineAnnotationPostProcessor`. Consequently, this results in a warning log indicating that some `PostProcessor`s cannot process it. While it's true that the `StateMachineAnnotationPostProcessorConfiguration` class does not actually require any `PostProcessor` processing, SpringBoot is not intelligent enough to discern this. Though this warning is rather harmless, it can be somewhat bothersome to individuals with OCD😄.