### PR TITLE
Fix turnstile and showcase sample

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	implementation("org.springframework:spring-core")
 	implementation 'org.asciidoctor:asciidoctor-gradle-jvm:3.3.2'
 	implementation 'org.jfrog.buildinfo:build-info-extractor-gradle:4.29.0'
+	implementation "org.springframework.boot:org.springframework.boot.gradle.plugin:${springBootVersion}"
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/java/org/springframework/statemachine/gradle/SamplePlugin.java
+++ b/buildSrc/src/main/java/org/springframework/statemachine/gradle/SamplePlugin.java
@@ -19,6 +19,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.PluginManager;
+import org.springframework.boot.gradle.plugin.SpringBootPlugin;
 
 /**
  * @author Janne Valkealahti
@@ -30,6 +31,7 @@ class SamplePlugin implements Plugin<Project> {
 		PluginManager pluginManager = project.getPluginManager();
 		pluginManager.apply(JavaPlugin.class);
 		pluginManager.apply(ManagementConfigurationPlugin.class);
+		pluginManager.apply(SpringBootPlugin.class);
 		new JavaConventions().apply(project);
 		new EclipseConventions().apply(project);
 	}

--- a/spring-statemachine-platform/spring-statemachine-platform.gradle
+++ b/spring-statemachine-platform/spring-statemachine-platform.gradle
@@ -10,10 +10,10 @@ description = 'Spring Statemachine BOM'
 
 dependencies {
 	api platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion")
+	api platform("org.springframework.shell:spring-shell-dependencies:$springShellVersion")
 	constraints {
 		api "com.google.code.findbugs:jsr305:$findbugsVersion"
 		api "com.esotericsoftware:kryo-shaded:$kryoVersion"
-		api "org.springframework.shell:spring-shell-core:$springShellVersion"
 		api "jakarta.persistence:jakarta.persistence-api:$jakartaPersistenceVersion"
 		api "org.eclipse.uml2:uml:$eclipseUml2UmlVersion"
 		api "org.eclipse.uml2:types:$eclipseUml2TypesVersion"

--- a/spring-statemachine-samples/showcase/spring-statemachine-samples-showcase.gradle
+++ b/spring-statemachine-samples/showcase/spring-statemachine-samples-showcase.gradle
@@ -8,7 +8,7 @@ dependencies {
 	management platform(project(":spring-statemachine-platform"))
 	implementation project(':spring-statemachine-samples-common')
 	implementation project(':spring-statemachine-core')
-	implementation 'org.springframework.shell:spring-shell-core'
+	implementation 'org.springframework.shell:spring-shell-starter'
 	testImplementation(testFixtures(project(':spring-statemachine-core')))
 	testImplementation (project(':spring-statemachine-test'))
 	testImplementation 'org.hamcrest:hamcrest-core'

--- a/spring-statemachine-samples/showcase/src/main/java/demo/showcase/Application.java
+++ b/spring-statemachine-samples/showcase/src/main/java/demo/showcase/Application.java
@@ -20,8 +20,10 @@ import java.util.Map;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.shell.command.annotation.CommandScan;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 import org.springframework.statemachine.config.EnableStateMachine;
@@ -30,7 +32,8 @@ import org.springframework.statemachine.config.builders.StateMachineStateConfigu
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 import org.springframework.statemachine.guard.Guard;
 
-@Configuration
+@CommandScan
+@SpringBootApplication(scanBasePackages = "demo")
 public class Application  {
 
 	private final static Log log = LogFactory.getLog(Application.class);

--- a/spring-statemachine-samples/showcase/src/main/java/demo/showcase/StateMachineCommands.java
+++ b/spring-statemachine-samples/showcase/src/main/java/demo/showcase/StateMachineCommands.java
@@ -18,14 +18,13 @@ package demo.showcase;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.shell.command.annotation.Command;
 import org.springframework.shell.command.annotation.Option;
-import org.springframework.stereotype.Component;
 
 import demo.AbstractStateMachineCommands;
 import demo.showcase.Application.Events;
 import demo.showcase.Application.States;
 import reactor.core.publisher.Mono;
 
-@Component
+@Command
 public class StateMachineCommands extends AbstractStateMachineCommands<States, Events> {
 
 	@Command(command = "sm event", description = "Sends an event to a state machine")

--- a/spring-statemachine-samples/showcase/src/main/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/spring-statemachine-samples/showcase/src/main/resources/META-INF/spring/spring-shell-plugin.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
-	<context:component-scan base-package="demo" />
-</beans>

--- a/spring-statemachine-samples/showcase/src/main/resources/application.properties
+++ b/spring-statemachine-samples/showcase/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.shell.interactive.enabled=true

--- a/spring-statemachine-samples/spring-statemachine-samples.gradle
+++ b/spring-statemachine-samples/spring-statemachine-samples.gradle
@@ -10,3 +10,7 @@ dependencies {
 	implementation 'org.springframework.shell:spring-shell-core'
 	implementation 'org.springframework.boot:spring-boot-starter'
 }
+
+tasks.named("bootJar") {
+	enabled = false
+}

--- a/spring-statemachine-samples/turnstile/spring-statemachine-samples-turnstile.gradle
+++ b/spring-statemachine-samples/turnstile/spring-statemachine-samples-turnstile.gradle
@@ -8,7 +8,7 @@ dependencies {
 	management platform(project(":spring-statemachine-platform"))
 	implementation project(':spring-statemachine-samples-common')
 	implementation project(':spring-statemachine-core')
-	implementation 'org.springframework.shell:spring-shell-core'
+	implementation 'org.springframework.shell:spring-shell-starter'
 	testImplementation(testFixtures(project(':spring-statemachine-core')))
 	testImplementation (project(':spring-statemachine-test'))
 	testImplementation 'org.hamcrest:hamcrest-core'

--- a/spring-statemachine-samples/turnstile/src/main/java/demo/turnstile/Application.java
+++ b/spring-statemachine-samples/turnstile/src/main/java/demo/turnstile/Application.java
@@ -18,13 +18,16 @@ package demo.turnstile;
 import java.util.EnumSet;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.shell.command.annotation.CommandScan;
 import org.springframework.statemachine.config.EnableStateMachine;
 import org.springframework.statemachine.config.EnumStateMachineConfigurerAdapter;
 import org.springframework.statemachine.config.builders.StateMachineStateConfigurer;
 import org.springframework.statemachine.config.builders.StateMachineTransitionConfigurer;
 
-@Configuration
+@CommandScan
+@SpringBootApplication(scanBasePackages = "demo")
 public class Application  {
 
 //tag::snippetA[]

--- a/spring-statemachine-samples/turnstile/src/main/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/spring-statemachine-samples/turnstile/src/main/resources/META-INF/spring/spring-shell-plugin.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
-	<context:component-scan base-package="demo" />
-</beans>

--- a/spring-statemachine-samples/turnstile/src/main/resources/application.properties
+++ b/spring-statemachine-samples/turnstile/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.shell.interactive.enabled=true

--- a/spring-statemachine-samples/turnstile/src/test/java/demo/turnstile/TurnstileTests.java
+++ b/spring-statemachine-samples/turnstile/src/test/java/demo/turnstile/TurnstileTests.java
@@ -137,7 +137,7 @@ public class TurnstileTests {
 	@BeforeEach
 	public void setup() {
 		context = new AnnotationConfigApplicationContext();
-		context.register(CommonConfiguration.class, Application.class, Config.class, StateMachineCommands.class);
+		context.register(CommonConfiguration.class, Application.class, Config.class);
 		context.refresh();
 		machine = context.getBean(StateMachineSystemConstants.DEFAULT_ID_STATEMACHINE, ObjectStateMachine.class);
 		listener = context.getBean(TestListener.class);


### PR DESCRIPTION
Resolves #1176

With the changes from this PR, the samples turnstile, turnstilereactive, and showcase work as described in the reference documentation.

I didn't check the other samples interactively, but their tests are still successful.

As all samples are Spring Boot applications, I've added the Spring Boot Gradle Plugin to the `SamplePlugin`. This lets the build produce executable jars that can be started with `java -jar` as described in the documentation.

To get the Spring Shell apps for the turnstile and showcase working, I've 

- enabled auto-configuration with `@SpringBootApplication`
- removed the application context XML (no longer required with `@SpringBootApplication`)
- added the `spring-shell-starter`
- set the property `spring.shell.interactive.enabled=true`
- added `@CommandScan` to pick up the sample commands

The other Spring Shell apps like e.g. the CD player should be fixable with the same approach.

The warning on start-up of the samples about the `StateMachineAnnotationPostProcessorConfiguration` can be resolved by #1157 .