### PR TITLE
fix: remove redundant double semicolon

### DIFF
--- a/buildSrc/src/main/java/org/springframework/statemachine/gradle/RootPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/statemachine/gradle/RootPlugin.java
@@ -64,7 +64,7 @@ class RootPlugin implements Plugin<Project> {
 			p.getPlugins().withType(AsciidoctorJPlugin.class, a -> {
 				p.getTasksByName("asciidoctor", false).forEach(t -> {
 					zipTask.dependsOn(t);
-				});;
+				});
 			});
 		});
 


### PR DESCRIPTION
## Description
I found a minor typo (redundant double semicolon `;;`) and cleaned it up. 

## Checklist
- [x] I have signed-off my commits according to the DCO.
- [x] This is a minor typo fix, so I didn't create a separate JIRA issue.
- [x] I followed the whitespace convention (Tabs).

Thanks for the great framework! 🚀