### PR TITLE
Use strict equality in extractElementNode

### DIFF
--- a/spring-statemachine-samples/web/src/main/resources/static/lib/angular-animate/angular-animate.js
+++ b/spring-statemachine-samples/web/src/main/resources/static/lib/angular-animate/angular-animate.js
@@ -108,7 +108,7 @@ function extractElementNode(element) {
   if (!element[0]) return element;
   for (var i = 0; i < element.length; i++) {
     var elm = element[i];
-    if (elm.nodeType == ELEMENT_NODE) {
+    if (elm.nodeType === ELEMENT_NODE) {
       return elm;
     }
   }


### PR DESCRIPTION
extractElementNode is close — The loose equality here can coerce values in ways that are hard to spot later. this patch tightens it to strict equality. Happy to drop this if it doesn’t fit.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.